### PR TITLE
Fixed prompt not getting wiped on esc

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -182,6 +182,7 @@ end
 function M.setup_buffers()
   vim.api.nvim_buf_set_option(M.state.input_buf, 'buftype', 'prompt')
   vim.api.nvim_buf_set_option(M.state.input_buf, 'filetype', 'fff_input')
+  vim.api.nvim_buf_set_option(M.state.input_buf, 'bufhidden', 'wipe')
   vim.fn.prompt_setprompt(M.state.input_buf, M.state.config.prompt)
 
   vim.api.nvim_buf_set_option(M.state.list_buf, 'buftype', 'nofile')


### PR DESCRIPTION
When pressing escape with something in the prompt, it counted as a modified buffer, so i couldnt quit with :q, only with :qa!. This fixes it, but im not sure if this is the best way to do it