### PR TITLE
Added main config to picker UI

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1053,7 +1053,7 @@ function M.open(opts)
     end
   end
 
-  M.state.config = vim.tbl_deep_extend('force', default_config, opts or {})
+  M.state.config = vim.tbl_deep_extend('force', default_config, main.config or {}, opts or {})
 
   if not M.create_ui() then
     vim.notify('Failed to create picker UI', vim.log.levels.ERROR)


### PR DESCRIPTION
The picker UI wasn't reading the options passed in at setup time, making it difficult to adjust picker width, height, etc. Better to include them, but allow the `open(opts)` options to overwrite them.