### PR TITLE
Fix: Exit insert mode and cleanup buffers when closing picker

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -971,6 +971,7 @@ function M.select(action)
   local relative_path = vim.fn.fnamemodify(item.path, ':.')
   file_picker.access_file(relative_path)
 
+  vim.cmd('stopinsert')
   M.close()
 
   local file_path = item.path
@@ -989,6 +990,7 @@ end
 function M.close()
   if not M.state.active then return end
 
+  vim.cmd('stopinsert')
   M.state.active = false
 
   local windows = {
@@ -1001,6 +1003,20 @@ function M.close()
 
   for _, win in ipairs(windows) do
     if win and vim.api.nvim_win_is_valid(win) then vim.api.nvim_win_close(win, true) end
+  end
+
+  -- Delete all buffers to prevent E37 error when quitting
+  local buffers = {
+    M.state.input_buf,
+    M.state.list_buf,
+    M.state.preview_buf,
+    M.state.file_info_buf,
+  }
+  
+  for _, buf in ipairs(buffers) do
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
   end
 
   M.state.input_win = nil


### PR DESCRIPTION
## Summary
This PR fixes three related issues with the file picker:
- Files opening in insert mode instead of normal mode when selected
- User remaining in insert mode when closing picker without selecting a file
- E37 error when quitting Vim after using the picker

## Changes
1. Added `vim.cmd('stopinsert')` in the `select` function before closing the picker
2. Added `vim.cmd('stopinsert')` at the beginning of the `close` function
3. Added proper buffer cleanup in the `close` function to delete all created buffers

## Testing
- Open the picker with `<C-p>`
- Select a file - it now opens in normal mode ✓
- Open the picker again and press `<Esc>` - you return to normal mode ✓
- Open the picker and close it, then try `:q\!` - no E37 error ✓

Fixes #8