### PR TITLE
Add missing comma in Lazy install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ FFF.nvim requires:
   build = "cargo build --release",
   opts = {
     -- pass here all the options
-  }
+  },
   keys = {
     {
       "<leader>ff", -- try it if you didn't it is a banger keybinding for a picker


### PR DESCRIPTION
This makes the example syntactically valid.