### PR TITLE
fix: fail to load if `CARGO_TARGET_DIR` is set

### DIFF
--- a/lua/fff/rust/init.lua
+++ b/lua/fff/rust/init.lua
@@ -8,14 +8,18 @@ end
 -- search for the lib in the /target/release directory with and without the lib prefix
 -- since MSVC doesn't include the prefix
 local base_path = debug.getinfo(1).source:match('@?(.*/)')
-package.cpath = package.cpath
-  .. ';'
-  .. base_path
-  .. '../../../target/release/lib?'
-  .. get_lib_extension()
-  .. ';'
-  .. base_path
-  .. '../../../target/release/?'
-  .. get_lib_extension()
+
+local paths = {
+  base_path .. '../../../target/release/lib?' .. get_lib_extension(),
+  base_path .. '../../../target/release/?' .. get_lib_extension(),
+}
+
+local cargo_target_dir = os.getenv('CARGO_TARGET_DIR')
+if cargo_target_dir then
+  table.insert(paths, cargo_target_dir .. '/release/lib?' .. get_lib_extension())
+  table.insert(paths, cargo_target_dir .. '/release/?' .. get_lib_extension())
+end
+
+package.cpath = package.cpath .. ';' .. table.concat(paths, ';')
 
 return require('fff_nvim')


### PR DESCRIPTION
# Summary

Fixes #6.

Currently if the user have environment variable `CARGO_TARGET_DIR` set, it will fail to load the shared library `libfff_nvim.so`. This PR fixes it by adding the directory to `package.cpath`.