### PR TITLE
fix: Support macOS .dylib extension in release script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,9 @@
           set -euo pipefail
           nix build
           mkdir -p target/release
-          cp -vf result/lib/libfff_nvim.so target/release/libfff_nvim.so
+          ext=so
+          if [ "$(uname)" = "Darwin" ]; then ext=dylib; fi
+          cp -vf result/lib/libfff_nvim.$ext target/release/libfff_nvim.so
           rm result
           echo "Library copied to target/release/"
         '';


### PR DESCRIPTION
## Motivation

On macOS, Rust `cdylib` outputs are named `*.dylib`, not `*.so`. So it's impossible to build with nix-darwin machines. This change fixes it.