### PR TITLE
security: fix shell injection vulnerabilities in file path handling

### DIFF
--- a/lua/fff/file_picker/image.lua
+++ b/lua/fff/file_picker/image.lua
@@ -158,7 +158,7 @@ end
 --- @return number|nil, number|nil Width and height in pixels
 function M.get_image_dimensions(file_path)
   -- Try file command first
-  local cmd = string.format('file "%s"', file_path)
+  local cmd = string.format('file %s', vim.fn.shellescape(file_path))
   local result = vim.fn.system(cmd)
 
   if vim.v.shell_error == 0 then
@@ -167,7 +167,7 @@ function M.get_image_dimensions(file_path)
   end
 
   -- Fallback to identify command (ImageMagick)
-  cmd = string.format('identify -format "%%w %%h" "%s" 2>/dev/null', file_path)
+  cmd = string.format('identify -format "%%w %%h" %s 2>/dev/null', vim.fn.shellescape(file_path))
   result = vim.fn.system(cmd)
 
   if vim.v.shell_error == 0 then

--- a/lua/fff/file_picker/preview.lua
+++ b/lua/fff/file_picker/preview.lua
@@ -323,7 +323,7 @@ end
 --- @return table|nil Lines of content, nil if failed
 function M.read_file_tail(file_path, tail_lines)
   -- Use system tail command for efficiency
-  local cmd = string.format('tail -n %d "%s" 2>/dev/null', tail_lines, file_path)
+  local cmd = string.format('tail -n %d %s 2>/dev/null', tail_lines, vim.fn.shellescape(file_path))
   local result = vim.fn.system(cmd)
 
   if vim.v.shell_error ~= 0 then
@@ -488,7 +488,7 @@ function M.preview_binary_file(file_path, bufnr, info, file)
 
   -- Try to get more information about the binary file
   if vim.fn.executable('file') == 1 then
-    local cmd = string.format('file -b "%s"', file_path)
+    local cmd = string.format('file -b %s', vim.fn.shellescape(file_path))
     local result = vim.fn.system(cmd)
     if vim.v.shell_error == 0 and result then
       result = result:gsub('\n', '')
@@ -502,7 +502,7 @@ function M.preview_binary_file(file_path, bufnr, info, file)
     table.insert(lines, 'Hex dump (first 1KB):')
     table.insert(lines, '')
 
-    local cmd = string.format('xxd -l 1024 "%s"', file_path)
+    local cmd = string.format('xxd -l 1024 %s', vim.fn.shellescape(file_path))
     local hex_result = vim.fn.system(cmd)
     if vim.v.shell_error == 0 and hex_result then
       local hex_lines = vim.split(hex_result, '\n')


### PR DESCRIPTION
## Summary

Fixes shell injection vulnerabilities in file path handling where malicious file names could potentially execute arbitrary commands.

## What was the issue?

A few system command calls were using unescaped file paths, which could be problematic if someone created files with special shell characters in their names.

For example, a file named `image.jpg; rm -rf /` could cause issues when the picker tries to preview it.

## What changed?

Updated **5 system command calls** across 2 files to use `vim.fn.shellescape()` for proper path escaping:

##### `lua/fff/file_picker/image.lua`
- Fixed `file` and `identify` commands in `get_image_dimensions()`

##### `lua/fff/file_picker/preview.lua`  
- Fixed `tail` command in `read_file_tail()`
- Fixed `file` and `xxd` commands in `preview_binary_file()`

**The fix**:
```lua
-- Before
string.format('command "%s"', file_path)

-- After  
string.format('command %s', vim.fn.shellescape(file_path))
```

## Testing

- Verified the picker still works normally with regular files
- Tested with files that have special characters in their names
- Image previews and binary file handling work as expected