### PR TITLE
Fix release script for Nix users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,11 @@
           src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
-          nativeBuildInputs = [ pkgs.pkg-config ];
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.perl
+          ];
+
           buildInputs = with pkgs; [
             # Add additional build inputs here
             openssl
@@ -52,9 +56,9 @@
           commonArgs
           // {
             cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
           }
         );
+
         # Create a script that copies the build result
         release-script = pkgs.writeShellScriptBin "release" ''
           set -euo pipefail


### PR DESCRIPTION
Previously, I got an error when building using `nix run .#release`:

```
>   Error configuring OpenSSL build:
>       Command 'perl' not found. Is perl installed?
>       Command failed: cd "/build/source/target/release/build/openssl-sys-487a1de5f6188f0d/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="gcc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/build/source/target/release/build/openssl-sys-487a1de5f6188f0d/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-module" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-ssl3" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64"

error: 1 dependencies of derivation '/nix/store/7lp1ij75mycpq5lmsqrimlzc9xkr6vxn-fff_nvim-0.1.0.drv' failed to build 
```

This PR addresses this by adding `perl` to the native build inputs and thus fixes this:

```
> nix run .#release
'result/lib/libfff_nvim.so' -> 'target/release/libfff_nvim.so'
removed 'target/release/libfff_nvim.so'
Library copied to target/release/
```