### PR TITLE
Fix/issue#32 should not show debug preview pannel when preview is disable

### DIFF
--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,4 +1,4 @@
-*fff.nvim.txt*         For Neovim >= 0.8.0         Last change: 2025 August 03
+*fff.nvim.txt*         For Neovim >= 0.8.0         Last change: 2025 August 04
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1040,7 +1040,7 @@ function M.open(opts)
     end
   end
 
-  M.state.config = main.config
+  M.state.config = vim.tbl_deep_extend('force', main.config or {}, opts or {})
 
   if not M.create_ui() then
     vim.notify('Failed to create picker UI', vim.log.levels.ERROR)

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -49,7 +49,10 @@ function M.create_ui()
 
   if not M.state.ns_id then M.state.ns_id = vim.api.nvim_create_namespace('fff_picker_status') end
 
-  local debug_enabled = main.config and main.config.debug and main.config.debug.show_scores
+  local debug_enabled_in_preview = M.enabled_preview()
+    and main.config
+    and main.config.debug
+    and main.config.debug.show_scores
 
   local width = math.floor(vim.o.columns * config.width)
   local height = math.floor(vim.o.lines * config.height)
@@ -62,7 +65,7 @@ function M.create_ui()
 
   local file_info_height = 0
   local preview_height = list_height
-  if debug_enabled then
+  if debug_enabled_in_preview then
     file_info_height = 10 -- Fixed height of 10 lines for file info
     preview_height = list_height - file_info_height -- No subtraction needed - borders are handled by window positioning
   end
@@ -72,7 +75,7 @@ function M.create_ui()
   M.state.list_buf = vim.api.nvim_create_buf(buf_opts[1], buf_opts[2])
   if M.enabled_preview() then M.state.preview_buf = vim.api.nvim_create_buf(buf_opts[1], buf_opts[2]) end
 
-  if debug_enabled then
+  if debug_enabled_in_preview then
     M.state.file_info_buf = vim.api.nvim_create_buf(buf_opts[1], buf_opts[2])
   else
     M.state.file_info_buf = nil
@@ -90,7 +93,7 @@ function M.create_ui()
     title_pos = 'left',
   })
 
-  if debug_enabled then
+  if debug_enabled_in_preview then
     M.state.file_info_win = vim.api.nvim_open_win(M.state.file_info_buf, false, {
       relative = 'editor',
       width = preview_width,
@@ -106,8 +109,8 @@ function M.create_ui()
     M.state.file_info_win = nil
   end
 
-  local preview_row = debug_enabled and (row + file_info_height + 3) or (row + 1)
-  local preview_height_adj = debug_enabled and preview_height or (list_height + 2)
+  local preview_row = debug_enabled_in_preview and (row + file_info_height + 3) or (row + 1)
+  local preview_height_adj = debug_enabled_in_preview and preview_height or (list_height + 2)
 
   if M.enabled_preview() then
     M.state.preview_win = vim.api.nvim_open_win(M.state.preview_buf, false, {


### PR DESCRIPTION
- Fix: state.config should merge main.config and manual options.
- Fix: Do not create the debug panel when the enable_preview option is falsy.


https://github.com/user-attachments/assets/1a513c94-9e2c-49ce-b2c5-8b786e5c87a1

Resolve: #32 
