### PR TITLE
Add perl to nativeBuildInputs to build openss-sys

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
           src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
-          nativeBuildInputs = [ pkgs.pkg-config ];
+          nativeBuildInputs = with pkgs [ pkg-config perl ];
           buildInputs = with pkgs; [
             # Add additional build inputs here
             openssl


### PR DESCRIPTION
```
 >   running cd "/private/tmp/nix-build-fff_nvim-deps-0.1.0.drv-0/source/target/release/build/openssl-sys-c175da57cd6380b1/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="clang" RANLIB="ranlib" "perl" "./Configure" "--prefix=/private/tmp/nix-build-fff_nvim-deps-0.1.0.drv-0/source/target/release/build/openssl-sys-c175da57cd6380b1/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-module" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-ssl3" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "darwin64-arm64-cc" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-macosx" "-mmacosx-version-min=11.3"
 >   cargo:warning=configuring OpenSSL build: Command 'perl' not found. Is perl installed?
 >   cargo:warning=openssl-src: failed to build OpenSSL from source
 >
 >   --- stderr
 >
 >
 >
 >   Error configuring OpenSSL build:
 >       Command 'perl' not found. Is perl installed?
 >       Command failed: cd "/private/tmp/nix-build-fff_nvim-deps-0.1.0.drv-0/source/target/release/build/openssl-sys-c175da57cd6380b1/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="clang" RANLIB="ranlib" "perl" "./Configure" "--prefix=/private/tmp/nix-build-fff_nvim-deps-0.1.0.drv-0/source/target/release/build/openssl-sys-c175da57cd6380b1/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-module" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-ssl3" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "darwin64-arm64-cc" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-macosx" "-mmacosx-version-min=11.3"
```