### PR TITLE
Fix: vim.notify() Expects string

### DIFF
--- a/lua/fff/file_picker/preview.lua
+++ b/lua/fff/file_picker/preview.lua
@@ -478,7 +478,7 @@ function M.scroll(lines)
   if not M.state.winid or not vim.api.nvim_win_is_valid(M.state.winid) then return end
 
   local win_height = vim.api.nvim_win_get_height(M.state.winid)
-  vim.notify(win_height)
+  vim.notify(tostring(win_height))
   local content_height = M.state.content_height or 0
 
   -- allows scrolling for a full content + half window


### PR DESCRIPTION
On NVIM v0.11.3 and Lua 5.1 errors were thrown when you tried to scroll in a preview.
It was caused by `vim.notify(win_height)` and `tostring()` solves the problem. 

<img width="1207" height="181" alt="image" src="https://github.com/user-attachments/assets/909d33b4-e261-41b4-bf17-f633da21011c" />
