### PR TITLE
fix: Files count indicator values

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -775,7 +775,11 @@ function M.update_status(progress)
     status_info = string.format('Indexing files %d', progress.scanned_files_count)
   else
     local search_metadata = file_picker.get_search_metadata()
-    status_info = string.format('%d/%d', search_metadata.total_matched, search_metadata.total_files)
+    if #M.state.query < 2 then
+      status_info = string.format('%d', search_metadata.total_files)
+    else
+      status_info = string.format('%d/%d', search_metadata.total_matched, search_metadata.total_files)
+    end
   end
 
   if status_info == M.state.last_status_info then return end

--- a/lua/fff/rust/file_picker.rs
+++ b/lua/fff/rust/file_picker.rs
@@ -191,16 +191,14 @@ impl FilePicker {
         };
 
         let time = std::time::Instant::now();
-        let (items, scores) = match_and_score_files(files, &context);
+        let (items, scores, total_matched) = match_and_score_files(files, &context);
         debug!(
             "Fuzzy search completed in {:?}: found {} results for query '{}', top result {:?}",
             time.elapsed(),
-            items.len(),
+            total_matched,
             query,
             items.first(),
         );
-
-        let total_matched = items.len();
         SearchResult {
             items,
             scores,


### PR DESCRIPTION
Fixes the issue with always displaying elements requested by lua (100) in the file count, fixes the issue of not showing the indicator on the second open. Unified the way it shows the value on first and substantial opens.

<img width="356" height="170" alt="image" src="https://github.com/user-attachments/assets/ca74dd18-2f0b-4561-8abe-42e8b884efa4" />
