### PR TITLE
fix: disable syntax highlighting for input buffer

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -437,6 +437,13 @@ function M.setup_buffers()
   vim.api.nvim_buf_set_option(M.state.input_buf, 'filetype', 'fff_input')
   vim.fn.prompt_setprompt(M.state.input_buf, M.state.config.prompt)
 
+  -- Changing the contents of the input buffer will trigger Neovim to guess the language in order to provide
+  -- syntax highlighting. This makes sure that it's always off.
+  vim.api.nvim_create_autocmd('Syntax', {
+    buffer = M.state.input_buf,
+    callback = function() vim.api.nvim_buf_set_option(M.state.input_buf, 'syntax', '') end,
+  })
+
   vim.api.nvim_buf_set_option(M.state.list_buf, 'buftype', 'nofile')
   vim.api.nvim_buf_set_option(M.state.list_buf, 'filetype', 'fff_list')
   vim.api.nvim_buf_set_option(M.state.list_buf, 'modifiable', false)


### PR DESCRIPTION
When `syntax` is enabled Neovim tries really hard to provide syntax highlighting. This is the simplest way I found to disable it for just one buffer.

Setting `syntax = ''` when the buffer is created is not enough, it will get overwritten on changes to the buffer and setting `syntax = ''` on buffer change wasn't 100% reliable for some reason.

Buffer scoped autocmds are cleaned up when the buffer is destroyed.

Fixes: https://github.com/dmtrKovalenko/fff.nvim/issues/112