### PR TITLE
fix cpath related errors

### DIFF
--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,4 +1,4 @@
-*fff.nvim.txt*       For Neovim >= 0.10.0       Last change: 2025 September 17
+*fff.nvim.txt*        For Neovim >= 0.10.0        Last change: 2025 October 04
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*

--- a/lua/fff/download.lua
+++ b/lua/fff/download.lua
@@ -187,4 +187,11 @@ function M.get_binary_path()
   return get_binary_path(plugin_dir)
 end
 
+function M.get_binary_cpath_component()
+  local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':h:h')
+  local binary_dir = get_binary_dir(plugin_dir)
+  local extension = system.get_lib_extension()
+  return binary_dir .. '/lib?.' .. extension
+end
+
 return M

--- a/lua/fff/rust/init.lua
+++ b/lua/fff/rust/init.lua
@@ -12,7 +12,7 @@ end
 local base_path = debug.getinfo(1).source:match('@?(.*/)')
 
 local paths = {
-  download.get_binary_path(),
+  download.get_binary_cpath_component(),
   base_path .. '../../../target/release/lib?' .. get_lib_extension(),
   base_path .. '../../../target/release/?' .. get_lib_extension(),
 }


### PR DESCRIPTION
Current way of configuring cpath use the full path of the downloaded binary without any '?', this causes any require statement that can't resolve before this cpath component to always resolve to the downloaded libfff_nvim, thus causing some unexpected bug in some other plugins or user code.

fixes errors like this:
```
Error executing vim.schedule lua callback: error loading module 'blink_cmp_fuzzy' from file '/Users/quolpr/.local/share/nvim/lazy/fff.nvim/lua/../target/libfff_nvim.dylib':
        dlsym(0x92987180, luaopen_blink_cmp_fuzzy): symbol not found
stack traceback:
        [C]: at 0x0103251790
        [C]: at 0x0103251b88
        [C]: in function 'require'
        ...l/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/init.lua:17: in function 'set_implementation'
        .../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:24: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```