### PR TITLE
feat: add ratio-based row/col positioning with centered defaults

### DIFF
--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -128,6 +128,8 @@ all available options:
         layout = {
           height = 0.8,
           width = 0.8,
+          row = nil, -- ratio (0.0 = top edge, 1.0 = bottom edge) nil is centered
+          col = nil, -- ratio (0.0 = left edge, 1.0 = right edge) nil is centered
           prompt_position = 'bottom', -- or 'top'
           preview_position = 'right', -- or 'left', 'right', 'top', 'bottom'
           preview_size = 0.5,

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -294,8 +294,39 @@ function M.create_ui()
 
   local width = math.floor(terminal_width * width_ratio)
   local height = math.floor(terminal_height * height_ratio)
-  local col = math.floor((vim.o.columns - width) / 2)
-  local row = math.floor((vim.o.lines - height) / 2)
+
+  -- Calculate col and row (support function or number)
+  local col_ratio_default = 0.5 - (width_ratio / 2) -- default center
+  local col_ratio
+  if config.layout.col ~= nil then
+    col_ratio = utils.resolve_config_value(
+      config.layout.col,
+      terminal_width,
+      terminal_height,
+      utils.is_valid_ratio,
+      col_ratio_default,
+      'layout.col'
+    )
+  else
+    col_ratio = col_ratio_default
+  end
+  local row_ratio_default = 0.5 - (height_ratio / 2) -- default center
+  local row_ratio
+  if config.layout.row ~= nil then
+    row_ratio = utils.resolve_config_value(
+      config.layout.row,
+      terminal_width,
+      terminal_height,
+      utils.is_valid_ratio,
+      row_ratio_default,
+      'layout.row'
+    )
+  else
+    row_ratio = row_ratio_default
+  end
+
+  local col = math.floor(terminal_width * col_ratio)
+  local row = math.floor(terminal_height * row_ratio)
 
   local prompt_position = get_prompt_position()
   local preview_position = get_preview_position()


### PR DESCRIPTION
adds row and col ratio values to layout, enables user to move window to the top for example.
nil = centered

<img width="1563" height="1361" alt="image" src="https://github.com/user-attachments/assets/ca78568f-f0fc-43d6-9265-8e64622a93c2" />