### PR TITLE
fix: Autofiletype detection for certain filetypes

### DIFF
--- a/.github/workflows/panvimdoc.yaml
+++ b/.github/workflows/panvimdoc.yaml
@@ -32,6 +32,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_author: ${{ steps.last-commit.outputs.author }}
-          commit_message: ${{ steps.last-commit.outputs.message }}
-          commit_options: "--amend --no-edit"
-          push_options: "--force"
+          commit_message: chore: Update docs for - ${{ steps.last-commit.outputs.message }}


### PR DESCRIPTION
closes https://github.com/dmtrKovalenko/fff.nvim/issues/174

I decided to call plenary as a lot of users have it installed anyway but if it is not installed just AI generated list of the most common file type flaws including ts