### PR TITLE
Make input and picker borders connected

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -386,8 +386,7 @@ function M.create_ui()
     row = layout.list_row,
     -- To make the input feel connected with the picker, we customize the
     -- respective corner border characters based on prompt_position
-    border = prompt_position == 'bottom'
-      and { '┌', '─', '┐', '│', '', '', '', '│' }
+    border = prompt_position == 'bottom' and { '┌', '─', '┐', '│', '', '', '', '│' }
       or { '├', '─', '┤', '│', '┘', '─', '└', '│' },
     style = 'minimal',
   }
@@ -442,8 +441,7 @@ function M.create_ui()
     row = layout.input_row,
     -- To make the input feel connected with the picker, we customize the
     -- respective corner border characters based on prompt_position
-    border = prompt_position == 'bottom'
-      and { '├', '─', '┤', '│', '┘', '─', '└', '│' }
+    border = prompt_position == 'bottom' and { '├', '─', '┤', '│', '┘', '─', '└', '│' }
       or { '┌', '─', '┐', '│', '', '', '', '│' },
     style = 'minimal',
   }


### PR DESCRIPTION
Unclear if this would be a PR that you would be willing to accept, but came up with a quick border tweak to make the input and picker windows feel more connected:

**BEFORE:**
<img width="2864" height="2166" alt="CleanShot 2025-11-02 at 01 40 54" src="https://github.com/user-attachments/assets/b8e22ea4-3f0f-488e-9776-1c5346c3b46e" />

**AFTER:**
<img width="2864" height="2166" alt="CleanShot 2025-11-02 at 01 40 06" src="https://github.com/user-attachments/assets/9e127928-fb79-46b5-bc2a-8eb3d8c95a29" />
