### PR TITLE
Add custom action framework to fff.nvim picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ require('fff').setup({
       preview_scroll_up = '<C-u>',
       preview_scroll_down = '<C-d>',
       toggle_debug = '<F2>',
+      actions = {}, -- map additional keybinds to named actions
     },
     hl = {
       border = 'FloatBorder',
@@ -166,6 +167,7 @@ require('fff').setup({
       enabled = true,
       db_path = vim.fn.stdpath('cache') .. '/fff_nvim',
     },
+    actions = {}, -- define custom actions here
     debug = {
       enabled = false, -- Set to true to show scores in the UI
       show_scores = false,
@@ -189,6 +191,30 @@ require('fff').scan_files()                         -- Trigger rescan of files i
 require('fff').refresh_git_status()                 -- Refresh git status for the active file lock
 require('fff').find_files_in_dir(path)              -- Find files in a specific directory
 require('fff').change_indexing_directory(new_path)  -- Change the base directory for the file picker
+```
+
+### Custom actions
+
+You can register snack-style actions and map them to additional keys. Actions receive the current item context (`ctx.item`, `ctx.path`, `ctx.relative_path`, `ctx.query`, `ctx.location`, and `ctx.close_picker()` to close manually).
+Built-in action names you can reuse: `edit`, `split`, `vsplit`, `tab`.
+
+```lua
+require('fff').setup({
+  actions = {
+    open_in_gh = {
+      desc = 'Browse file on GitHub',
+      callback = function(ctx)
+        vim.fn.jobstart({ 'gh', 'browse', ctx.relative_path }, { detach = true })
+      end,
+      -- set close = false to keep the picker open after running
+    },
+  },
+  keymaps = {
+    actions = {
+      ['<C-b>'] = { action = 'open_in_gh', mode = { 'n', 'i' } },
+    },
+  },
+})
 ```
 
 #### Commands

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -160,6 +160,7 @@ all available options:
           preview_scroll_up = '<C-u>',
           preview_scroll_down = '<C-d>',
           toggle_debug = '<F2>',
+          actions = {},
         },
         hl = {
           border = 'FloatBorder',
@@ -176,6 +177,7 @@ all available options:
           enabled = true,
           db_path = vim.fn.stdpath('cache') .. '/fff_nvim',
         },
+        actions = {},
         debug = {
           enabled = false, -- Set to true to show scores in the UI
           show_scores = false,
@@ -201,6 +203,33 @@ AVAILABLE METHODS
     require('fff').refresh_git_status()                 -- Refresh git status for the active file lock
     require('fff').find_files_in_dir(path)              -- Find files in a specific directory
     require('fff').change_indexing_directory(new_path)  -- Change the base directory for the file picker
+<
+
+CUSTOM ACTIONS ~
+
+Register snack-like custom actions in `actions` and bind them with
+`keymaps.actions`. Actions receive a context table with `ctx.item`,
+`ctx.path`, `ctx.relative_path`, `ctx.query`, `ctx.location`, and
+`ctx.close_picker()` to close the picker manually.
+Built-in action names you can reuse: `edit`, `split`, `vsplit`, `tab`.
+
+>lua
+    require('fff').setup({
+      actions = {
+        open_in_gh = {
+          desc = 'Open file on GitHub',
+          callback = function(ctx)
+            vim.fn.jobstart({ 'gh', 'browse', ctx.relative_path }, { detach = true })
+          end,
+          -- set close = false to keep the picker open after running
+        },
+      },
+      keymaps = {
+        actions = {
+          ['<C-b>'] = { action = 'open_in_gh', mode = { 'n', 'i' } },
+        },
+      },
+    })
 <
 
 

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -140,6 +140,7 @@ local function init()
       preview_scroll_up = '<C-u>',
       preview_scroll_down = '<C-d>',
       toggle_debug = '<F2>',
+      actions = {},
     },
     hl = {
       border = 'FloatBorder',
@@ -156,6 +157,7 @@ local function init()
       enabled = true,
       db_path = vim.fn.stdpath('cache') .. '/fff_nvim',
     },
+    actions = {},
     debug = {
       enabled = false, -- Set to true to show scores in the UI
       show_scores = false,


### PR DESCRIPTION
  - introduce a custom action framework for the picker: built-ins (edit, split, vsplit, tab) plus user-defined
    callbacks get rich context (item, path, relative_path, query, location, and close_picker())
  - make it easy to bind extra keys via keymaps.actions with optional mode filters while keeping defaults
    unchanged
  - document how to add your own action, e.g.:
```lua
    require('fff').setup({
      actions = {
        open_in_gh = function(ctx)
          vim.fn.jobstart({ 'gh', 'browse', ctx.relative_path }, { detach = true })
        end,
      },
      keymaps = {
        actions = {
          ['<C-b>'] = { action = 'open_in_gh', mode = { 'n', 'i' } },
        },
      },
    })
```