### PR TITLE
fix: Do not rely on the global cpath

### DIFF
--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -43,9 +43,14 @@ local function setup_global_autocmds(config)
       local new_cwd = vim.v.event.cwd
       if state.initialized and new_cwd and new_cwd ~= config.base_path then
         vim.schedule(function()
-          local picker = require('fff.main')
-          local ok, err = pcall(picker.change_indexing_directory, new_cwd)
+          -- Delay require to avoid circular dependency: core -> main -> picker_ui -> file_picker -> core
+          local ok, picker = pcall(require, 'fff.main')
           if not ok then
+            vim.notify('FFF: Failed to load main module: ' .. tostring(picker), vim.log.levels.ERROR)
+            return
+          end
+          local change_ok, err = pcall(picker.change_indexing_directory, new_cwd)
+          if not change_ok then
             vim.notify('FFF: Failed to change indexing directory: ' .. tostring(err), vim.log.levels.ERROR)
           end
         end)

--- a/lua/fff/download.lua
+++ b/lua/fff/download.lua
@@ -14,7 +14,7 @@ local function get_current_version(plugin_dir, callback)
   end)
 end
 
-local function get_binary_dir(plugin_dir) return plugin_dir .. '/../target' end
+local function get_binary_dir(plugin_dir) return plugin_dir .. '/../target/release' end
 
 local function get_binary_path(plugin_dir)
   local binary_dir = get_binary_dir(plugin_dir)

--- a/lua/fff/rust/init.lua
+++ b/lua/fff/rust/init.lua
@@ -9,7 +9,13 @@ end
 
 -- search for the lib in the /target/release directory with and without the lib prefix
 -- since MSVC doesn't include the prefix
-local base_path = debug.getinfo(1).source:match('@?(.*/)')
+local info = debug.getinfo(1, 'S')
+local base_path = info and info.source and info.source:match('@?(.*/)') or ''
+
+-- Fallback: if base_path is nil, try to determine from current file path
+if not base_path or base_path == '' then
+  base_path = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.expand('<sfile>:p')), ':h') .. '/'
+end
 
 local paths = {
   download.get_binary_cpath_component(),
@@ -23,11 +29,28 @@ if cargo_target_dir then
   table.insert(paths, cargo_target_dir .. '/release/?' .. get_lib_extension())
 end
 
-package.cpath = package.cpath .. ';' .. table.concat(paths, ';')
+-- Instead of using require (which can find the wrong lib due to cpath pollution),
+-- load the library directly from the first valid path we find
+local function try_load_library()
+  for _, path_pattern in ipairs(paths) do
+    local actual_path = path_pattern:gsub('%?', 'fff_nvim')
+    local stat = vim.uv.fs_stat(actual_path)
+    if stat and stat.type == 'file' then
+      local loader, err = package.loadlib(actual_path, 'luaopen_fff_nvim')
+      if loader then return loader() end
+    end
+  end
+  return nil, 'No valid library found in any search path'
+end
 
-local ok, backend = pcall(require, 'fff_nvim')
-if not ok then
-  error('Failed to load fff rust backend. Make sure that it has been downloaded or built with `cargo build --release`')
+local backend, load_err = try_load_library()
+if not backend then
+  local err_msg = string.format(
+    'Failed to load fff rust backend.\nError: %s\nSearched paths:\n%s\nMake sure binary exists with `cargo build --release`',
+    tostring(load_err),
+    vim.inspect(paths)
+  )
+  error(err_msg)
 end
 
 return backend


### PR DESCRIPTION
As appeared package.cpath is global and other plugins can pollute it so we can not rely on this. Specifcially codesnap.nvim is breaking fff