### PR TITLE
fix: directory_path highlight is not working if there are no icons

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1265,8 +1265,11 @@ function M.render_list()
           end
 
           -- Directory path highlighting
-          if icon and #filename > 0 and #dir_path > 0 then
-            local prefix_len = #icon + 1 + #filename + 1 -- icon bytes + space + filename bytes + space
+          if #filename > 0 and #dir_path > 0 then
+            local prefix_len = #filename + 1 -- filename bytes + space
+            if icon then
+                prefix_len = prefix_len + #icon + 1 -- if icon add icon bytes + space
+            end
             vim.api.nvim_buf_add_highlight(
               M.state.list_buf,
               M.state.ns_id,


### PR DESCRIPTION
if there is no icons plugin installed, the directory path highlighting does not work

<img width="1043" height="123" alt="image" src="https://github.com/user-attachments/assets/220ca3f8-cedf-4507-abc3-c406b7857c13" />
