### PR TITLE
fix: Not downloadable binary

### DIFF
--- a/lua/fff/rust/init.lua
+++ b/lua/fff/rust/init.lua
@@ -37,6 +37,7 @@ local function try_load_library()
     local stat = vim.uv.fs_stat(actual_path)
     if stat and stat.type == 'file' then
       local loader, err = package.loadlib(actual_path, 'luaopen_fff_nvim')
+      if err then return nil, string.format('Error loading library from %s: %s', actual_path, err) end
       if loader then return loader() end
     end
   end
@@ -44,12 +45,13 @@ local function try_load_library()
 end
 
 local backend, load_err = try_load_library()
-if not backend then
+if not backend or load_err then
   local err_msg = string.format(
-    'Failed to load fff rust backend.\nError: %s\nSearched paths:\n%s\nMake sure binary exists with `cargo build --release`',
+    'Failed to load fff rust backend.\nError: %s\nSearched paths:\n%s\nMake sure binary exists or make it exists using \n `:lua require("fff.download").download_or_build_binary()`\nor\n`cargo build --release`\n(and rerun neovim after)',
     tostring(load_err),
     vim.inspect(paths)
   )
+
   error(err_msg)
 end
 

--- a/lua/fff/utils.lua
+++ b/lua/fff/utils.lua
@@ -59,4 +59,35 @@ function M.is_one_of(value, values)
   return false
 end
 
+-- Recursively create directories using uv.fs_mkdir
+local function mkdir_recursive(path, callback)
+  vim.uv.fs_stat(path, function(err, stat)
+    if not err and stat then
+      callback(true, nil)
+      return
+    end
+
+    local parent = vim.fn.fnamemodify(path, ':h')
+    if parent == path or parent == '' or parent == '.' then
+      callback(false, 'Cannot create root directory')
+      return
+    end
+
+    mkdir_recursive(parent, function(parent_ok, parent_err)
+      if not parent_ok then
+        callback(false, parent_err)
+        return
+      end
+
+      uv.fs_mkdir(path, 493, function(mkdir_err) -- 493 = 0755 octal
+        if mkdir_err and not mkdir_err:match('EEXIST') then
+          callback(false, 'Failed to create directory: ' .. mkdir_err)
+          return
+        end
+        callback(true, nil)
+      end)
+    end)
+  end)
+end
+
 return M


### PR DESCRIPTION
closes https://github.com/dmtrKovalenko/fff.nvim/issues/196

This issue was related to the fact that I chagned vim.mkdir to vim.uv.fs_mkdir but it is not recursive so when you installed a fresh version it never created the dir for it.