### PR TITLE
fix(picker_ui.lua): Vim E33 fnamemodify error in picker_ui.lua (possible fix for #148)

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1931,7 +1931,10 @@ local function get_current_file_cache(base_path)
   local absolute_path = vim.fn.fnamemodify(current_file, ':p')
   local resolved_abs = vim.fn.resolve(absolute_path)
   local resolved_base = vim.fn.resolve(base_path)
-  local escaped_base = resolved_base:gsub("([%%^$()%.%[%]*+%-?])", "%%%1")
+
+  -- icloud direcrtoes on macos contain a lot of special characters that break
+  -- the fnamemodify which have to escaped with %
+  local escaped_base = resolved_base:gsub('([%%^$()%.%[%]*+%-?])', '%%%1')
   local relative_path = resolved_abs:gsub('^' .. escaped_base .. '/', '')
   if relative_path == '' or relative_path == resolved_abs then return nil end
   return relative_path


### PR DESCRIPTION

# Error Running into E33 with iCloud tilda paths

Issue : [#148 ](https://github.com/dmtrKovalenko/fff.nvim/issues/148)

Error coming from picker_ui.lua fnamemodify in relative_path
at function `get_current_file_cache(base_path)`

### Replicate Error Behavior:
- Open up `vim .` from a directory inside iCloud directory that contains `~` ,such as `iCloud~md~obsidian/<directory>` 
- Run picker find files the first time (with keybind) works fine.
- When inside the buffer. Run picker find files again -> Run into **Error Vim:E33 fnamemodify**
- But if pull up Oil file tree. File picker still works. 

For me the error seems to only show up when running File picker that has `~` tilda path in the file buffer
itself, not when in Oil file tree. It did not behave like this before, only happened maybe after some iCloud sync.

> ERROR

```lua
E5108: Error executing lua: Vim:E33: No previous substitute regular expression
stack traceback:
[C]: in function 'fnamemodify'
...al/.local/share/nvim/lazy/fff.nvim/lua/fff/picker_ui.lua:1933: in function 'get_current_file_cache'
...al/.local/share/nvim/lazy/fff.nvim/lua/fff/picker_ui.lua:2072: in function 'open'
...ersonal/.local/share/nvim/lazy/fff.nvim/lua/fff/main.lua:17: in function 'find_files'
/Users/personal/.config/nvim/lua/sethy/plugins/fff.lua:103: in function </Users/personal/.config/nvi
m/lua/sethy/plugins/fff.lua:102>
```

### Purposed Fix: 

Please test this out. Been using this fix on macos for about 3 days.
Haven't ran into any issues yet. 

Works with tilda paths or iCloud ~ paths. Vim:E33 error mentioned above is no longer showing.
After fix, file picker runs fine when
- start up with `vim .` to open a file with picker find files
- when in the file buffer, run file picker again now works for ~ iCloud directories (no Vim:E33 error)
- no issues calling file picker when in oil.nvim file tree and when inside file buffer itself

Everything else should hopefully behave the same way it did before.

- replaced `fnamemodify :s?` with Lua string matching using `gsub`
- strips the `base_path` and handles ~ or ? and others.

> FIX
```lua
local absolute_path = vim.fn.fnamemodify(current_file, ':p')
local resolved_abs = vim.fn.resolve(absolute_path)
local resolved_base = vim.fn.resolve(base_path)
local escaped_base = resolved_base:gsub("([%%^$()%.%[%]*+%-?])", "%%%1")
local relative_path = resolved_abs:gsub('^' .. escaped_base .. '/', '')
if relative_path == '' or relative_path == resolved_abs then return nil end
return relative_path

```

I tried testing custom path with this made up dir. This is
probably not the best way to test it but it does work here. Again please verify, see if this could work.

- `mkdir -p ~/test\?dir/subdir`
- `touch ~/test\?dir/subdir/testfile.txt` and `touch ~/test\?dir/subdir/test=file.txt`
- `cd ~/test\?dir/subdir`
- `nvim testfile.txt`


