### PR TITLE
docs: Document file filtering with .ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ require('fff').setup({
 })
 ```
 
+#### File Filtering
+
+FFF.nvim respects `.gitignore` patterns automatically. To filter files from the picker without modifying `.gitignore`, create a `.ignore` file in your project root:
+
+```gitignore
+# Exclude all markdown files
+*.md
+
+# Exclude specific subdirectory
+docs/archive/**/*.md
+```
+
+Run `:FFFScan` to force a rescan if needed.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Adds documentation for file filtering using `.ignore` files.

I was trying to filter markdown files from my picker and couldn't find any info about it in the README. After digging through the code, I found that FFF already supports `.gitignore` patterns and `.ignore` files - it just wasn't documented anywhere.

This PR adds a brief section explaining how to use `.ignore` files to filter files without modifying `.gitignore`.