### PR TITLE
fix: ignore window-scoped DirChanged events

### DIFF
--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -46,6 +46,7 @@ local function setup_global_autocmds(config)
   vim.api.nvim_create_autocmd('DirChanged', {
     group = group,
     callback = function()
+      if vim.v.event.scope == 'window' then return end
       local new_cwd = vim.v.event.cwd
       if state.initialized and new_cwd and new_cwd ~= config.base_path then
         vim.schedule(function()


### PR DESCRIPTION
some plugins modify their local base directory using `:lcd`, e.g. Git-related tools such as Neogit. currently fff reacts to these window-scoped events which can throw it off and cause major performance issues. For example, when I am in my config (`~/.config/nvim`) that's part of my dotfiles repo, the Git root is set to `$HOME`. Since fff provides a picker for the project CWD we should only respond to global or tab-scoped `DirChanged` events. I believe that we can safely disregard window-scoped events.