### PR TITLE
feat: Support initial query for live_grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ require('fff').live_grep({
     modes = { 'fuzzy' },
   }
 })
+
+-- Pre-fill the search with an initial query
+require('fff').live_grep({ query = 'search term' })
 ```
 
 When only one mode is configured, the mode indicator is hidden completely and the cycle keybind does nothing.

--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -25,6 +25,7 @@ end
 --- @param opts.layout? table Layout overrides
 --- @param opts.grep? table Grep-specific overrides {max_file_size, smart_case, max_matches_per_file, modes}
 --- @param opts.grep.modes? table Available search modes and their cycling order (default: {'plain', 'regex', 'fuzzy'})
+--- @param opts.query? string Initial search query to pre-fill
 function M.live_grep(opts)
   local picker_ok, picker_ui = pcall(require, 'fff.picker_ui')
   if not picker_ok then
@@ -42,6 +43,7 @@ function M.live_grep(opts)
     mode = 'grep',
     renderer = grep_renderer,
     grep_config = grep_config,
+    query = opts and opts.query or nil,
   })
 
   picker_ui.open(picker_opts)

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2521,7 +2521,8 @@ function M.open(opts)
   end
 
   local current_file_cache = get_current_file_cache(base_path)
-  return open_ui_with_state(nil, nil, nil, merged_config, current_file_cache)
+  local query = opts and opts.query or nil
+  return open_ui_with_state(query, nil, nil, merged_config, current_file_cache)
 end
 
 function M.monitor_scan_progress(iteration)


### PR DESCRIPTION
## Summary
- Add `query` option to `live_grep()` to pre-fill the picker with an initial search string
- Useful for programmatic integrations like "grep word under cursor" keybindings

## Usage

```lua
require('fff').live_grep({ query = 'search term' })
```

## Changes
- `picker_ui.open`: Pass `opts.query` through to `open_ui_with_state`
- `main.live_grep`: Forward `opts.query` to picker
- README: Added example in per-call configuration section

This PR was authored using the help of Claude Code