### PR TITLE
fix: warnings on flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,13 @@
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
+        cargoToml = builtins.fromTOML (builtins.readFile ./crates/fff-nvim/Cargo.toml);
+
         # Common arguments can be set here to avoid repeating them later
         # Note: changes here will rebuild all dependency crates
         commonArgs = {
+          pname = cargoToml.package.name;
+          version = cargoToml.package.version;
           src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 


### PR DESCRIPTION
If you clone the repo and run `nix run .#release` you get the following warnings. This PR fixes the warnings.

```
evaluation warning: crane will use a placeholder value since `version` cannot be found in /nix/store/q512d346vra6iw8v8585raxg9wd66l6x-Cargo.toml
                    to silence this warning consider one of the following:
                    - setting `version = "...";` in the derivation arguments explicitly
                    - setting `package.version = "..."` or `workspace.package.version` = "..." in the root Cargo.toml
                    - explicitly looking up the values from a different Cargo.toml via
                      `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
                    To find the source of this warning, rerun nix with:
                    `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
evaluation warning: crane will use a placeholder value since `name` cannot be found in /nix/store/q512d346vra6iw8v8585raxg9wd66l6x-Cargo.toml
                    to silence this warning consider one of the following:
                    - setting `pname = "...";` in the derivation arguments explicitly
                    - setting `package.name = "..."` or `package.metadata.crane.name` = "..." or `workspace.metadata.crane.name` = "..." in the root Cargo.toml
                    - explicitly looking up the values from a different Cargo.toml via
                      `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
                    To find the source of this warning, rerun nix with:
                    `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
evaluation warning: crane will use a placeholder value since `version` cannot be found in /nix/store/q512d346vra6iw8v8585raxg9wd66l6x-Cargo.toml
                    to silence this warning consider one of the following:
                    - setting `version = "...";` in the derivation arguments explicitly
                    - setting `package.version = "..."` or `workspace.package.version` = "..." in the root Cargo.toml
                    - explicitly looking up the values from a different Cargo.toml via
                      `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
                    To find the source of this warning, rerun nix with:
                    `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
evaluation warning: crane will use a placeholder value since `name` cannot be found in /nix/store/q512d346vra6iw8v8585raxg9wd66l6x-Cargo.toml
                    to silence this warning consider one of the following:
                    - setting `pname = "...";` in the derivation arguments explicitly
                    - setting `package.name = "..."` or `package.metadata.crane.name` = "..." or `workspace.metadata.crane.name` = "..." in the root Cargo.toml
                    - explicitly looking up the values from a different Cargo.toml via
                      `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
                    To find the source of this warning, rerun nix with:
                    `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
```