### PR TITLE
fix: Use consistent emoji for frecency debug star indicator

### DIFF
--- a/lua/fff/file_renderer.lua
+++ b/lua/fff/file_renderer.lua
@@ -72,7 +72,7 @@ function M.render_line(item, ctx, item_idx)
       if mod >= 6 then
         indicator = '🔥'
       elseif access >= 4 then
-        indicator = '⭐'
+        indicator = '⭐️'
       elseif total >= 3 then
         indicator = '✨'
       elseif total >= 1 then
@@ -149,7 +149,7 @@ function M.apply_highlights(item, ctx, item_idx, buf, ns_id, line_idx, line_cont
 
   -- 4. Frecency indicator
   if ctx.debug_enabled then
-    local start_pos, end_pos = line_content:find('[⭐🔥✨•]%d+')
+    local start_pos, end_pos = line_content:find('[⭐️🔥✨•]%d+')
     if start_pos then
       vim.api.nvim_buf_add_highlight(buf, ns_id, ctx.config.hl.frecency, line_idx - 1, start_pos - 1, end_pos)
     end


### PR DESCRIPTION
Change the star from (U+2B50) to (U+2B50 + U+FE0F) to enforce it to be an emoji for the debugging frequency mode (You can see the text-based star in the screenshot below). It seemed off and once tried to make the frecency icon stuff configurable, but just realized it's just a debug feature. Very nit-picky change, so feel free to skip it if you don't like. 

<img width="424" height="462" alt="2026-02-18-163602_hyprshot" src="https://github.com/user-attachments/assets/d0525f71-521d-4333-8535-9961994509fe" />