### PR TITLE
docs: update readme example keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ FFF.nvim requires:
     },
     {
       "fz",
-	  function() require('fff').live_grep({
-		grep = {
-			modes = { 'fuzzy', 'plain' }
-	    }
-	  }) end,
+      function() require('fff').live_grep({
+        grep = {
+          modes = { 'fuzzy', 'plain' }
+        }
+      }) end,
       desc = 'Live fffuzy grep',
     },
     {


### PR DESCRIPTION
Added an example to query grep with word under cursor to the README.

I had this config with snacks.picker, i think it was in their docs a few time ago, I find it a really great finding