### PR TITLE
fix: replace flex = nil with flex = false in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ require('fff').setup({
       prompt_position = 'bottom', -- or 'top'
       preview_position = 'right', -- or 'left', 'right', 'top', 'bottom'
       preview_size = 0.5,
-      flex = { -- set to nil to disable flex layout
+      flex = { -- set to false to disable flex layout
         size = 130, -- column threshold: if screen width >= size, use preview_position; otherwise use wrap
         wrap = 'top', -- position to use when screen is narrower than size
       },


### PR DESCRIPTION
I found that setting `layout.flex` to `nil` (as described in the README.md) doesn't disable the flex layout for some reason. However, `false` works just fine. This PR updates the `README.md` to reflect this.