### PR TITLE
fix: implement clear_cache function for FFFClearCache command

### DIFF
--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -216,10 +216,13 @@ function M.clear_cache(scope)
   scope = scope or 'all'
 
   local config = require('fff.conf').get()
+  local fuzzy = require('fff.fuzzy')
   local cleared = {}
 
   -- Clear frecency database
   if scope == 'all' or scope == 'frecency' then
+    -- Properly close LMDB before deleting to avoid memory-mapped file issues
+    pcall(fuzzy.destroy_db)
     local db_path = config.frecency and config.frecency.db_path
         or (vim.fn.stdpath('cache') .. '/fff_nvim')
     if vim.fn.isdirectory(db_path) == 1 then
@@ -230,6 +233,8 @@ function M.clear_cache(scope)
 
   -- Clear query history database
   if scope == 'all' or scope == 'files' then
+    -- Properly close query database before deleting
+    pcall(fuzzy.destroy_query_db)
     local hist_path = config.history and config.history.db_path
         or (vim.fn.stdpath('data') .. '/fff_queries')
     if vim.fn.isdirectory(hist_path) == 1 then

--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -210,4 +210,43 @@ function M.open_file_under_cursor(open_cb)
   end)
 end
 
+--- Clear FFF caches (frecency, history/file index, or both)
+--- @param scope? string "all" (default), "frecency", or "files"
+function M.clear_cache(scope)
+  scope = scope or 'all'
+
+  local config = require('fff.conf').get()
+  local cleared = {}
+
+  -- Clear frecency database
+  if scope == 'all' or scope == 'frecency' then
+    local db_path = config.frecency and config.frecency.db_path
+        or (vim.fn.stdpath('cache') .. '/fff_nvim')
+    if vim.fn.isdirectory(db_path) == 1 then
+      vim.fn.delete(db_path, 'rf')
+      table.insert(cleared, 'frecency')
+    end
+  end
+
+  -- Clear query history database
+  if scope == 'all' or scope == 'files' then
+    local hist_path = config.history and config.history.db_path
+        or (vim.fn.stdpath('data') .. '/fff_queries')
+    if vim.fn.isdirectory(hist_path) == 1 then
+      vim.fn.delete(hist_path, 'rf')
+      table.insert(cleared, 'history')
+    end
+  end
+
+  if #cleared == 0 then
+    vim.notify('FFF: No caches to clear', vim.log.levels.INFO)
+    return
+  end
+
+  vim.notify(
+    'FFF: Cleared ' .. table.concat(cleared, ', ') .. ' cache(s). Restart Neovim for changes to take full effect.',
+    vim.log.levels.INFO
+  )
+end
+
 return M


### PR DESCRIPTION
## Summary

The `:FFFClearCache` user command calls `require("fff").clear_cache()`, but this function did not exist, causing an error when running the command.

## Changes

- Add `clear_cache(scope)` function to `lua/fff/main.lua`
- Supports three modes:
  - `"all"` (default) - clears both frecency and history caches
  - `"frecency"` - clears only frecency database
  - `"files"` - clears only query history database

## Testing

```vim
:FFFClearCache        " clears all caches
:FFFClearCache all    " same as above
:FFFClearCache frecency
:FFFClearCache files
```

Closes #169