### PR TITLE
fix(grep): align preview highlight stripping with Rust query parser

### DIFF
--- a/crates/fff-nvim/src/lib.rs
+++ b/crates/fff-nvim/src/lib.rs
@@ -5,8 +5,9 @@ use fff::frecency::FrecencyTracker;
 use fff::path_utils::expand_tilde;
 use fff::query_tracker::QueryTracker;
 use fff::{
-    DbHealthChecker, Error, FFFMode, FileSearchConfig, FuzzySearchOptions, PaginationArgs,
-    QueryParser, Score, SearchResult, SharedFrecency, SharedPicker, SharedQueryTracker,
+    DbHealthChecker, Error, FFFMode, FileSearchConfig, FuzzySearchOptions, GrepConfig,
+    PaginationArgs, QueryParser, Score, SearchResult, SharedFrecency, SharedPicker,
+    SharedQueryTracker,
 };
 use mimalloc::MiMalloc;
 use mlua::prelude::*;
@@ -582,6 +583,18 @@ pub fn get_historical_grep_query(_: &Lua, offset: usize) -> LuaResult<Option<Str
         .into_lua_result()
 }
 
+/// Parse a grep query string and return its text portion (with constraints stripped).
+///
+/// Uses the Rust `GrepConfig` parser as the single source of truth, so Lua
+/// code never needs to re-implement constraint detection.
+pub fn parse_grep_query(lua: &Lua, query: String) -> LuaResult<LuaTable> {
+    let parser = QueryParser::new(GrepConfig);
+    let parsed = parser.parse(&query);
+    let table = lua.create_table()?;
+    table.set("grep_text", parsed.grep_text())?;
+    Ok(table)
+}
+
 pub fn wait_for_initial_scan(_: &Lua, timeout_ms: Option<u64>) -> LuaResult<bool> {
     // Extract the scan signal Arc WITHOUT holding the read lock, so the
     // scan thread can acquire the write lock to store its results.
@@ -822,6 +835,7 @@ fn create_exports(lua: &Lua) -> LuaResult<LuaTable> {
     exports.set("health_check", lua.create_function(health_check)?)?;
     exports.set("shorten_path", lua.create_function(shorten_path)?)?;
     exports.set("hex_dump", lua.create_function(hex_dump::hex_dump)?)?;
+    exports.set("parse_grep_query", lua.create_function(parse_grep_query)?)?;
 
     Ok(exports)
 }

--- a/lua/fff/fuzzy.lua
+++ b/lua/fff/fuzzy.lua
@@ -46,6 +46,7 @@ M.get_git_root = rust_module.get_git_root
 
 -- Grep functions
 M.live_grep = rust_module.live_grep
+M.parse_grep_query = rust_module.parse_grep_query
 
 -- Utility functions
 M.health_check = rust_module.health_check

--- a/lua/fff/location_utils.lua
+++ b/lua/fff/location_utils.lua
@@ -134,45 +134,6 @@ function M.highlight_location(bufnr, location, namespace)
   return #extmarks > 0 and extmarks or nil
 end
 
---- Check if a token is a grep constraint (matches Rust GrepConfig parser rules).
---- Keeps highlight stripping aligned with the actual query parser so preview
---- highlights match the grep results.
---- @param token string A single whitespace-delimited query token
---- @return boolean
-function M._is_grep_constraint(token)
-  if token == '' then return false end
-
-  -- Escaped tokens (leading \) are never constraints in the Rust parser
-  if token:sub(1, 1) == '\\' and #token > 1 then return false end
-
-  local first = token:sub(1, 1)
-
-  -- Extension: *.rs, *.{ts,tsx} (but not bare "*" or "*.")
-  if first == '*' then
-    if token == '*' or token == '*.' then return false end
-    if token:match('^%*%.') then return true end
-    return false
-  end
-
-  -- Exclusion: !foo, !*.rs
-  if first == '!' and #token > 1 then return true end
-
-  -- Path segment with leading slash: /src/, /lib
-  if first == '/' then return true end
-
-  -- Path segment with trailing slash: src/, lib/
-  if token:sub(-1) == '/' then return true end
-
-  -- Glob: tokens containing / or brace expansion with letters like {ts,tsx}
-  if token:find('/') then return true end
-  if token:match('{%a.*,%a.*}') then return true end
-
-  -- Type filter: type:rust
-  if token:match('^type:') then return true end
-
-  return false
-end
-
 --- Highlight all occurrences of a grep pattern in the preview buffer.
 --- For plain text and regex modes: highlights every match on all loaded lines
 --- using Lua string.find with the query text.
@@ -217,21 +178,12 @@ function M.highlight_grep_matches(bufnr, location, namespace)
 
   local query = location.grep_query
 
-  -- Extract search text by stripping constraint tokens, matching the Rust
-  -- query parser's GrepConfig rules (extensions, path segments, globs,
-  -- exclusions, type filters). Escaped leading backslash means "not a
-  -- constraint" in the Rust parser, so we keep those tokens too.
-  local parts = vim.split(query, '%s+')
-  local text_parts = {}
-  for _, part in ipairs(parts) do
-    if part ~= '' and not M._is_grep_constraint(part) then
-      -- Strip leading backslash when it escapes a constraint trigger (*, /, !)
-      -- so that e.g. \*.config highlights "*.config" not "\*.config"
-      if #part > 1 and part:sub(1, 1) == '\\' and part:sub(2, 2):match('[%*!/]') then part = part:sub(2) end
-      table.insert(text_parts, part)
-    end
-  end
-  local search_text = table.concat(text_parts, ' ')
+  -- Use the Rust GrepConfig parser as the single source of truth for
+  -- stripping constraint tokens. This avoids duplicating constraint
+  -- detection in Lua, which would break whenever a new token type is added.
+  local fuzzy = require('fff.fuzzy')
+  local parsed = fuzzy.parse_grep_query(query)
+  local search_text = parsed.grep_text
   if search_text == '' then search_text = query end
 
   if not search_text or search_text == '' then return nil end

--- a/lua/fff/location_utils.lua
+++ b/lua/fff/location_utils.lua
@@ -134,6 +134,45 @@ function M.highlight_location(bufnr, location, namespace)
   return #extmarks > 0 and extmarks or nil
 end
 
+--- Check if a token is a grep constraint (matches Rust GrepConfig parser rules).
+--- Keeps highlight stripping aligned with the actual query parser so preview
+--- highlights match the grep results.
+--- @param token string A single whitespace-delimited query token
+--- @return boolean
+function M._is_grep_constraint(token)
+  if token == '' then return false end
+
+  -- Escaped tokens (leading \) are never constraints in the Rust parser
+  if token:sub(1, 1) == '\\' and #token > 1 then return false end
+
+  local first = token:sub(1, 1)
+
+  -- Extension: *.rs, *.{ts,tsx} (but not bare "*" or "*.")
+  if first == '*' then
+    if token == '*' or token == '*.' then return false end
+    if token:match('^%*%.') then return true end
+    return false
+  end
+
+  -- Exclusion: !foo, !*.rs
+  if first == '!' and #token > 1 then return true end
+
+  -- Path segment with leading slash: /src/, /lib
+  if first == '/' then return true end
+
+  -- Path segment with trailing slash: src/, lib/
+  if token:sub(-1) == '/' then return true end
+
+  -- Glob: tokens containing / or brace expansion with letters like {ts,tsx}
+  if token:find('/') then return true end
+  if token:match('{%a.*,%a.*}') then return true end
+
+  -- Type filter: type:rust
+  if token:match('^type:') then return true end
+
+  return false
+end
+
 --- Highlight all occurrences of a grep pattern in the preview buffer.
 --- For plain text and regex modes: highlights every match on all loaded lines
 --- using Lua string.find with the query text.
@@ -178,16 +217,22 @@ function M.highlight_grep_matches(bufnr, location, namespace)
 
   local query = location.grep_query
 
-  -- Extract the actual search text from the grep query (strip file constraints like *.rs /src/)
-  -- The query parser uses space-separated tokens; the first non-constraint token is the pattern.
-  -- Simple heuristic: strip tokens that look like constraints (start with *, /, or !)
-  local search_text = query
+  -- Extract search text by stripping constraint tokens, matching the Rust
+  -- query parser's GrepConfig rules (extensions, path segments, globs,
+  -- exclusions, type filters). Escaped leading backslash means "not a
+  -- constraint" in the Rust parser, so we keep those tokens too.
   local parts = vim.split(query, '%s+')
   local text_parts = {}
   for _, part in ipairs(parts) do
-    if part ~= '' and not part:match('^[%*!/]') and not part:match('^%.') then table.insert(text_parts, part) end
+    if part ~= '' and not M._is_grep_constraint(part) then
+      -- Strip leading backslash when it escapes a constraint trigger (*, /, !)
+      -- so that e.g. \*.config highlights "*.config" not "\*.config"
+      if #part > 1 and part:sub(1, 1) == '\\' and part:sub(2, 2):match('[%*!/]') then part = part:sub(2) end
+      table.insert(text_parts, part)
+    end
   end
-  if #text_parts > 0 then search_text = text_parts[1] end
+  local search_text = table.concat(text_parts, ' ')
+  if search_text == '' then search_text = query end
 
   if not search_text or search_text == '' then return nil end
 


### PR DESCRIPTION
The Lua heuristic in `highlight_grep_matches` (location_utils.lua) used a simple prefix check to strip constraint tokens before highlighting. This diverged from the Rust `GrepConfig` parser in several ways:

- Multi-word queries like `foo bar *.rs` only highlighted `foo` (first text part), not the full search text
- `type:rust` and other key:value constraints weren't stripped
- Tokens starting with `.` were incorrectly treated as constraints
- Backslash-escaped constraints (e.g. `\*.config` as literal search text) weren't handled

This adds `_is_grep_constraint()` that matches the Rust parser's actual GrepConfig rules: extensions (`*.rs`), path segments (`/src/`), exclusions (`!test`), type filters (`type:rust`), and path-oriented globs. Text parts are now joined with space for highlighting, matching `grep_text()` on the Rust side.

Fixes #331

This contribution was developed with AI assistance (Claude Code).