### PR TITLE
doc: fix installation guide for vim.pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ vim.pack.add({ 'https://github.com/dmtrKovalenko/fff.nvim' })
 
 vim.api.nvim_create_autocmd('PackChanged', {
   callback = function(event)
-    if event.data.updated then
+    local name, kind = ev.data.spec.name, ev.data.kind
+    if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
+      if not ev.data.active then
+        vim.cmd.packadd('fff.nvim')
+      end
       require('fff.download').download_or_build_binary()
     end
   end,

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -122,9 +122,13 @@ VIM.PACK
     
     vim.api.nvim_create_autocmd('PackChanged', {
       callback = function(event)
-        if event.data.updated then
-          require('fff.download').download_or_build_binary()
-        end
+	local name, kind = ev.data.spec.name, ev.data.kind
+	if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
+	  if not ev.data.active then
+	    vim.cmd.packadd('fff.nvim')
+	  end
+	  require('fff.download').download_or_build_binary()
+	end
       end,
     })
     


### PR DESCRIPTION
What changed:
 - `download_or_build_binary()` is now executed not only during updates, but also during installation.
 - `download_or_build_binary()` is no longer executed for `PackChanged` events unrelated to fff.nvim.
