### PR TITLE
docs: fix syntax error in the installation guide for vim.pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ FFF.nvim requires neovim 0.10.0 or higher
 vim.pack.add({ 'https://github.com/dmtrKovalenko/fff.nvim' })
 
 vim.api.nvim_create_autocmd('PackChanged', {
-  callback = function(event)
+  callback = function(ev)
     local name, kind = ev.data.spec.name, ev.data.kind
     if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
       if not ev.data.active then

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -121,7 +121,7 @@ VIM.PACK
     vim.pack.add({ 'https://github.com/dmtrKovalenko/fff.nvim' })
     
     vim.api.nvim_create_autocmd('PackChanged', {
-      callback = function(event)
+      callback = function(ev)
         local name, kind = ev.data.spec.name, ev.data.kind
         if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
           if not ev.data.active then


### PR DESCRIPTION
Fix of #352

What changed:
- Fixed an issue where the callback took `event` as an argument but used `ev` inside the callback.
