### PR TITLE
Create new quickfix list instead of replacing current

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2285,7 +2285,7 @@ function M.send_to_quickfix()
   local is_grep = M.state.mode == 'grep'
   M.close()
 
-  vim.fn.setqflist(qf_list, 'r')
+  vim.fn.setqflist(qf_list)
   vim.cmd('copen')
 
   local count = #qf_list


### PR DESCRIPTION
The quickfix stack is very useful to keep track of multiple searches (e.g. with `:colder` and `:cnewer`). Currently, `C-q` replaces the current quickfix list instead of adding a new list to the stack.

This PR changes this to create a new quickfix list instead.