### PR TITLE
feat: optional vim-mode in prompt input

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ require('fff').setup({
     max_results = 100,
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
-    vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
+    prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
     layout = {
       height = 0.8,
       width = 0.8,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ require('fff').setup({
     max_results = 100,
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
+    vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
     layout = {
       height = 0.8,
       width = 0.8,

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -164,6 +164,7 @@ all available options:
         max_results = 100,
         max_threads = 4,
         lazy_sync = true, -- set to false if you want file indexing to start on open
+        vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
         layout = {
           height = 0.8,
           width = 0.8,

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -164,7 +164,7 @@ all available options:
         max_results = 100,
         max_threads = 4,
         lazy_sync = true, -- set to false if you want file indexing to start on open
-        vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
+        prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
         layout = {
           height = 0.8,
           width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -63,6 +63,7 @@ local M = {}
 --- @field max_results number
 --- @field max_threads number
 --- @field lazy_sync boolean
+--- @field vim_mode boolean
 --- @field layout FffLayoutConfig
 --- @field preview FffPreviewConfig
 --- @field keymaps FffKeymapsConfig
@@ -196,6 +197,7 @@ local function init()
     max_results = 100,
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
+    vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
     layout = {
       height = 0.8,
       width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -63,7 +63,7 @@ local M = {}
 --- @field max_results number
 --- @field max_threads number
 --- @field lazy_sync boolean
---- @field vim_mode boolean
+--- @field prompt_vim_mode boolean
 --- @field layout FffLayoutConfig
 --- @field preview FffPreviewConfig
 --- @field keymaps FffKeymapsConfig
@@ -197,7 +197,7 @@ local function init()
     max_results = 100,
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
-    vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode (motions like j/k/w/b/0/^), second <Esc> closes the picker
+    prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
     layout = {
       height = 0.8,
       width = 0.8,

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -904,9 +904,7 @@ function M.setup_keymaps()
       buffer = M.state.input_buf,
       callback = function()
         local prompt_len = #M.state.config.prompt
-        if vim.fn.col('.') <= prompt_len then
-          vim.fn.cursor(vim.fn.line('.'), prompt_len + 1)
-        end
+        if vim.fn.col('.') <= prompt_len then vim.fn.cursor(vim.fn.line('.'), prompt_len + 1) end
       end,
     })
   end

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -839,9 +839,14 @@ function M.setup_keymaps()
   set_keymap('i', keymaps.cycle_previous_query, M.recall_query_from_history, input_opts)
   set_keymap('n', 'j', M.move_down, input_opts)
   set_keymap('n', 'k', M.move_up, input_opts)
-  set_keymap('n', keymaps.close, M.close, input_opts)
   set_keymap('n', keymaps.focus_list, M.focus_list_win, input_opts)
   set_keymap('n', keymaps.focus_preview, M.focus_preview_win, input_opts)
+
+  if M.state.config.vim_mode then
+    set_keymap('n', keymaps.close, M.close, input_opts)
+  else
+    set_keymap({ 'i', 'n' }, keymaps.close, M.close, input_opts)
+  end
 
   set_keymap({ 'i', 'n' }, keymaps.select, M.select, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.select_split, function() M.select('split') end, input_opts)
@@ -894,15 +899,17 @@ function M.setup_keymaps()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
-    buffer = M.state.input_buf,
-    callback = function()
-      local prompt_len = #M.state.config.prompt
-      if vim.fn.col('.') <= prompt_len then
-        vim.fn.cursor(vim.fn.line('.'), prompt_len + 1)
-      end
-    end,
-  })
+  if M.state.config.vim_mode then
+    vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+      buffer = M.state.input_buf,
+      callback = function()
+        local prompt_len = #M.state.config.prompt
+        if vim.fn.col('.') <= prompt_len then
+          vim.fn.cursor(vim.fn.line('.'), prompt_len + 1)
+        end
+      end,
+    })
+  end
 end
 
 function M.focus_input_win()

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -893,6 +893,16 @@ function M.setup_keymaps()
       vim.schedule(function() M.on_input_change() end)
     end,
   })
+
+  vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+    buffer = M.state.input_buf,
+    callback = function()
+      local prompt_len = #M.state.config.prompt
+      if vim.fn.col('.') <= prompt_len then
+        vim.fn.cursor(vim.fn.line('.'), prompt_len + 1)
+      end
+    end,
+  })
 end
 
 function M.focus_input_win()

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -842,7 +842,7 @@ function M.setup_keymaps()
   set_keymap('n', keymaps.focus_list, M.focus_list_win, input_opts)
   set_keymap('n', keymaps.focus_preview, M.focus_preview_win, input_opts)
 
-  if M.state.config.vim_mode then
+  if M.state.config.prompt_vim_mode then
     set_keymap('n', keymaps.close, M.close, input_opts)
   else
     set_keymap({ 'i', 'n' }, keymaps.close, M.close, input_opts)
@@ -899,7 +899,7 @@ function M.setup_keymaps()
     end,
   })
 
-  if M.state.config.vim_mode then
+  if M.state.config.prompt_vim_mode then
     vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
       buffer = M.state.input_buf,
       callback = function()

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -839,11 +839,10 @@ function M.setup_keymaps()
   set_keymap('i', keymaps.cycle_previous_query, M.recall_query_from_history, input_opts)
   set_keymap('n', 'j', M.move_down, input_opts)
   set_keymap('n', 'k', M.move_up, input_opts)
+  set_keymap('n', keymaps.close, M.close, input_opts)
   set_keymap('n', keymaps.focus_list, M.focus_list_win, input_opts)
   set_keymap('n', keymaps.focus_preview, M.focus_preview_win, input_opts)
 
-  -- Input buffer: both modes
-  set_keymap({ 'i', 'n' }, keymaps.close, M.close, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.select, M.select, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.select_split, function() M.select('split') end, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.select_vsplit, function() M.select('vsplit') end, input_opts)


### PR DESCRIPTION
Resolves #383.

## Summary

- Adds opt-in `vim_mode` config flag (default `false`) that enables vim-style navigation in the picker prompt, mirroring Telescope's behavior.
- When enabled, `<Esc>` in insert mode falls through to Neovim's native `buftype=prompt` switch to normal mode; a second `<Esc>` closes the picker.
- Existing normal-mode bindings on the input buffer (`j`/`k` list navigation, `focus_list`, `focus_preview`) become reachable. Native motions `w`/`b`/`0`/`^`/`h`/`F<x>`/`T<x>` work on the query text.
- A `CursorMoved`/`CursorMovedI` guard clamps the cursor to the first byte after the prompt prefix (`🪿 `), so `0`/`^`/`b`/etc. can't land on the prefix.

## Changes

- `lua/fff/conf.lua`: add `vim_mode` field to `FffConfig`, default `false`.
- `lua/fff/picker_ui.lua`:
  - Bind `close` to `{i, n}` when `vim_mode = false` (original behavior); `n`-only when `vim_mode = true`.
  - Install the `CursorMoved`/`CursorMovedI` prompt-prefix guard only when `vim_mode = true`.
- `README.md`, `doc/fff.nvim.txt`: document the new option in the complete-options example.

Default-off, so existing users see no behavior change.

## Test plan

- [ ] With `vim_mode = false` (default): `<Esc>` in prompt closes picker (unchanged).
- [ ] With `vim_mode = true`: `<Esc>` in prompt enters normal mode; `j`/`k` scroll the list; `w`/`b` move within query text; `0`/`^` land on first char of query, not on the prefix; second `<Esc>` closes picker; `i`/`a`/`A` return to insert mode.
- [ ] Multi-byte prefix (default `🪿 `) is respected by the cursor guard.