### PR TITLE
fix: close picker immediately on <C-c> in vim mode

### DIFF
--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                            For Neovim >= 0.10.0    Last change: 2026 April 15
+                            For Neovim >= 0.10.0    Last change: 2026 April 17
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -844,6 +844,7 @@ function M.setup_keymaps()
 
   if M.state.config.prompt_vim_mode then
     set_keymap('n', keymaps.close, M.close, input_opts)
+    set_keymap('i', '<C-c>', M.close, input_opts)
   else
     set_keymap({ 'i', 'n' }, keymaps.close, M.close, input_opts)
   end


### PR DESCRIPTION
## Summary

- When `prompt_vim_mode` is enabled, `<C-c>` in insert mode now closes the picker immediately instead of just leaving insert mode to give a way to close the picker from insert mode directly.