### PR TITLE
fix: search_and_show type errors

### DIFF
--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -159,8 +159,9 @@ function M.search_and_show(query)
 
   for i, file in ipairs(files) do
     if i <= 15 then
-      local icon = file.extension ~= '' and '.' .. file.extension or '📄'
-      local frecency = file.frecency_score > 0 and ' ⭐' .. file.frecency_score or ''
+      local file_extension = vim.fn.fnamemodify(file.name, ':e')
+      local icon = file_extension ~= '' and '.' .. file_extension or '📄'
+      local frecency = file.total_frecency_score > 0 and ' ⭐' .. file.total_frecency_score or ''
       print('  ' .. i .. '. ' .. icon .. ' ' .. file.relative_path .. frecency)
     end
   end


### PR DESCRIPTION
Closes #416

I tried to maintain the previous behaviour, but not sure if the icons logic makes sense, as it just uses the file extension.
Let me know if you want any changes, or feel free to implement yourself/close this PR