### PR TITLE
fix: Do not treat single token as a path name prefitler

### DIFF
--- a/crates/fff-query-parser/src/config.rs
+++ b/crates/fff-query-parser/src/config.rs
@@ -91,13 +91,10 @@ pub trait ParserConfig {
         has_wildcards(token)
     }
 
-    /// When `true`, a PathSegment constraint that is the ONLY token in the
-    /// query is demoted to fuzzy text. Grep modes enable this because the
-    /// user is typing a search term (e.g. `/api/tests`), not scoping to a
-    /// directory. File-search modes keep the default (`false`) so that
-    /// `/src/` still filters by directory.
+    /// If `true`, a PathSegment constraint that is the ONLY token in the
+    /// query is demoted to fuzzy text to avoid over filtering
     fn treat_lone_path_as_text(&self) -> bool {
-        false
+        true
     }
 
     /// Custom constraint parsers for picker-specific needs
@@ -144,10 +141,6 @@ impl ParserConfig for GrepConfig {
 
     fn enable_location(&self) -> bool {
         false
-    }
-
-    fn treat_lone_path_as_text(&self) -> bool {
-        true
     }
 
     /// Only recognise globs that are clearly directory/path oriented.
@@ -220,10 +213,6 @@ impl ParserConfig for AiGrepConfig {
 
     fn enable_location(&self) -> bool {
         false
-    }
-
-    fn treat_lone_path_as_text(&self) -> bool {
-        true
     }
 
     fn is_glob_pattern(&self, token: &str) -> bool {

--- a/crates/fff-query-parser/src/parser.rs
+++ b/crates/fff-query-parser/src/parser.rs
@@ -1038,40 +1038,6 @@ mod tests {
     }
 
     #[test]
-    fn test_file_search_leading_slash_path_alone_stays_path_segment() {
-        // FileSearchConfig (fuzzy file finder) should still treat a lone
-        // `/api/tests/` as a PathSegment constraint — the user is scoping
-        // the file list to that directory.
-        let parser = QueryParser::new(FileSearchConfig);
-
-        let result = parser.parse("/api/tests/");
-        assert_eq!(
-            result.constraints.len(),
-            1,
-            "FileSearchConfig: expected PathSegment constraint, got {:?}",
-            result.constraints
-        );
-        assert!(
-            matches!(result.constraints[0], Constraint::PathSegment("api/tests")),
-            "FileSearchConfig: expected PathSegment(\"api/tests\"), got {:?}",
-            result.constraints[0]
-        );
-
-        let result = parser.parse("/api/tests");
-        assert_eq!(
-            result.constraints.len(),
-            1,
-            "FileSearchConfig: expected PathSegment constraint, got {:?}",
-            result.constraints
-        );
-        assert!(
-            matches!(result.constraints[0], Constraint::PathSegment("api/tests")),
-            "FileSearchConfig: expected PathSegment(\"api/tests\"), got {:?}",
-            result.constraints[0]
-        );
-    }
-
-    #[test]
     fn test_ai_grep_filename_with_extension_only_promotes_to_text() {
         // Same case with an Extension constraint — no fuzzy text means the
         // filename is what the user is searching for.

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                            For Neovim >= 0.10.0    Last change: 2026 April 26
+                            For Neovim >= 0.10.0    Last change: 2026 April 27
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*


### PR DESCRIPTION
closes https://github.com/dmtrKovalenko/fff.nvim/issues/420