### PR TITLE
fix(picker_ui): handle 'winfixbuf' when opening selected file

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2228,6 +2228,15 @@ function M.recall_query_from_history()
   end)
 end
 
+--- Check whether the given window has 'winfixbuf' enabled.
+--- pcall-guarded so this stays safe on Neovim versions that predate the option.
+--- @param win number Window ID
+--- @return boolean
+local function window_has_winfixbuf(win)
+  local ok, val = pcall(vim.api.nvim_get_option_value, 'winfixbuf', { win = win })
+  return ok and val == true
+end
+
 --- Find the first visible window with a normal file buffer
 --- @return number|nil Window ID of the first suitable window, or nil if none found
 local function find_suitable_window()
@@ -2254,6 +2263,7 @@ local function find_suitable_window()
           and modifiable
           and not is_picker_window
           and filetype ~= 'undotree'
+          and not window_has_winfixbuf(win)
         then
           return win
         end
@@ -2465,17 +2475,28 @@ function M.select(action)
   M.close()
 
   if action == 'edit' then
+    local current_win = vim.api.nvim_get_current_win()
     local current_buf = vim.api.nvim_get_current_buf()
     local current_buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
     local current_buf_modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
+    local current_winfixbuf = window_has_winfixbuf(current_win)
 
-    -- If current active buffer is not a normal buffer we find a suitable window with a tab otherwise opening a new split
-    if current_buftype ~= '' or not current_buf_modifiable then
+    -- If the current window can't host a new buffer (special buftype, non-modifiable,
+    -- or 'winfixbuf' locking it), retarget a suitable window or fall back to a split.
+    -- Without this, :edit raises E1513 ("Cannot switch buffer. 'winfixbuf' is enabled")
+    -- whenever the picker is invoked from a window pinned via :h winfixbuf.
+    local opened_via_split = false
+    if current_buftype ~= '' or not current_buf_modifiable or current_winfixbuf then
       local suitable_win = find_suitable_window()
-      if suitable_win then vim.api.nvim_set_current_win(suitable_win) end
+      if suitable_win then
+        vim.api.nvim_set_current_win(suitable_win)
+      elseif current_winfixbuf then
+        vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
+        opened_via_split = true
+      end
     end
 
-    vim.cmd('edit ' .. vim.fn.fnameescape(relative_path))
+    if not opened_via_split then vim.cmd('edit ' .. vim.fn.fnameescape(relative_path)) end
   elseif action == 'split' then
     vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
   elseif action == 'vsplit' then


### PR DESCRIPTION
## Problem

Selecting a file in the picker raises `E1513` whenever the source window has `winfixbuf` enabled:

```
Vim(edit):E1513: Cannot switch buffer. 'winfixbuf' is enabled
  at lua/fff/picker_ui.lua:2478 (in M.select)
```

`M.select`'s `edit` branch checks the current buffer's `buftype` / `modifiable`, but not the window-local `winfixbuf` option. `:h winfixbuf` is the documented mechanism (Neovim 0.10+) for pinning a window to its buffer; any code path that runs `:edit` must respect it, otherwise the picker becomes unusable from a pinned window.

## Why this isn't an obscure edge case

`winfixbuf` is the official "pin this window" API, not a niche flag. It fires in realistic flows:

- A user explicitly pins the current file (`:set winfixbuf`) to keep it as a reference while jumping around — and then opens the picker to look at something else.
- Sessions / view files (`:mksession`, auto-session, etc.) restore `winfixbuf` from a previous session.
- Plugins set `winfixbuf` on certain windows; if the picker's `find_suitable_window` happens to land on one of those windows, the same error fires even when the source window was a non-file buffer.

Other pickers (e.g. Telescope, Snacks.picker) already handle `winfixbuf` for this reason.

## Reproduction (minimal)

1. `:edit any_file.lua`
2. `:set winfixbuf`
3. Open the picker and select another file.

Expected: file opens. Actual: `E1513`, file is not opened.

## Fix

- Add a small helper `window_has_winfixbuf(win)` (pcall-guarded for Neovim < 0.10 where the option doesn't exist).
- `find_suitable_window`: skip windows where `winfixbuf` is set, so we never redirect into a pinned window.
- `M.select`'s `edit` branch: treat `winfixbuf` on the current window like a non-modifiable buftype — try `find_suitable_window` first; if no suitable window exists, fall back to `:split` so the file still opens without clobbering the pinned window.

Default path (no `winfixbuf` anywhere) is unchanged: `:edit` replaces the current buffer as before.

## Test scenarios verified

- [x] No `winfixbuf` → edit replaces current buffer (regression check, default path unchanged)
- [x] Single window with `winfixbuf` → falls back to `:split`, original window keeps its pinned buffer
- [x] Multiple windows, current is `winfixbuf` + another normal window exists → switches to the normal window and `:edit`
- [x] Quickfix open + main window `winfixbuf` → split fallback, no error
- [x] `:set nowinfixbuf` after fix → behavior identical to default path

## Notes

- No new dependencies, no behavior change for users not using `winfixbuf`.
- `pcall` around `nvim_get_option_value('winfixbuf', ...)` keeps the patch safe on Neovim versions predating the option.