### PR TITLE
fix: bound LMDB growth + deprecate unsafe no-lock mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,11 @@ This repository contains **FFF.nvim (Fast File Finder)**, a high-performance fil
 
 ## Development Commands
 
+Always prefer Makefile commands listed to the cargo/bun/node if possible.
+
 ### Building
 
-- `cargo build --release` - Build the Rust fuzzy matcher and file picker
+- `make build` - build everything
 
 ### Testing and Development Tools
 
@@ -17,7 +19,6 @@ This project does not have a traditional test suite. Testing is done through:
 
 ### Code Quality
 
-- `cargo fmt` - Format Rust code (follows standard conventions)
 - `make lint` - Rust linting and code analysis
 - `make format` - Format all code 
 - `make test` - Run unit tests (limited coverage, primarily integration testing)

--- a/crates/fff-c/include/fff.h
+++ b/crates/fff-c/include/fff.h
@@ -352,13 +352,16 @@ typedef struct FffMixedSearchResult {
  * cache-budget configuration. This function delegates to `fff_create_instance2`
  * with NULL log paths and auto cache budget, so behaviour is unchanged.
  *
+ * The `use_unsafe_no_lock` parameter is deprecated and ignored; see
+ * [`fff_create_instance2`] for details.
+ *
  * ## Safety
  * See `fff_create_instance2`.
  */
 struct FffResult *fff_create_instance(const char *base_path,
                                       const char *frecency_db_path,
                                       const char *history_db_path,
-                                      bool use_unsafe_no_lock,
+                                      bool _use_unsafe_no_lock,
                                       bool enable_mmap_cache,
                                       bool enable_content_indexing,
                                       bool watch,
@@ -375,7 +378,7 @@ struct FffResult *fff_create_instance(const char *base_path,
  * * `base_path`                   – directory to index (required)
  * * `frecency_db_path`            – frecency LMDB database path (NULL/empty to skip)
  * * `history_db_path`             – query history LMDB database path (NULL/empty to skip)
- * * `use_unsafe_no_lock`          – use MDB_NOLOCK for LMDB (useful in single-process setups)
+ * * `use_unsafe_no_lock`          – **deprecated, ignored.** Previously enabled
  * * `enable_mmap_cache`           – pre-populate mmap caches after the initial scan
  * * `enable_content_indexing`     – build content index after the initial scan
  * * `watch`                       – start a background file-system watcher for live updates
@@ -399,7 +402,7 @@ struct FffResult *fff_create_instance(const char *base_path,
 struct FffResult *fff_create_instance2(const char *base_path,
                                        const char *frecency_db_path,
                                        const char *history_db_path,
-                                       bool use_unsafe_no_lock,
+                                       bool _use_unsafe_no_lock,
                                        bool enable_mmap_cache,
                                        bool enable_content_indexing,
                                        bool watch,

--- a/crates/fff-c/src/lib.rs
+++ b/crates/fff-c/src/lib.rs
@@ -110,6 +110,9 @@ fn default_i32(val: i32, default: i32) -> i32 {
 /// cache-budget configuration. This function delegates to `fff_create_instance2`
 /// with NULL log paths and auto cache budget, so behaviour is unchanged.
 ///
+/// The `use_unsafe_no_lock` parameter is deprecated and ignored; see
+/// [`fff_create_instance2`] for details.
+///
 /// ## Safety
 /// See `fff_create_instance2`.
 #[unsafe(no_mangle)]
@@ -117,7 +120,7 @@ pub unsafe extern "C" fn fff_create_instance(
     base_path: *const c_char,
     frecency_db_path: *const c_char,
     history_db_path: *const c_char,
-    use_unsafe_no_lock: bool,
+    _use_unsafe_no_lock: bool,
     enable_mmap_cache: bool,
     enable_content_indexing: bool,
     watch: bool,
@@ -128,7 +131,7 @@ pub unsafe extern "C" fn fff_create_instance(
             base_path,
             frecency_db_path,
             history_db_path,
-            use_unsafe_no_lock,
+            false,
             enable_mmap_cache,
             enable_content_indexing,
             watch,
@@ -152,7 +155,11 @@ pub unsafe extern "C" fn fff_create_instance(
 /// * `base_path`                   – directory to index (required)
 /// * `frecency_db_path`            – frecency LMDB database path (NULL/empty to skip)
 /// * `history_db_path`             – query history LMDB database path (NULL/empty to skip)
-/// * `use_unsafe_no_lock`          – use MDB_NOLOCK for LMDB (useful in single-process setups)
+/// * `use_unsafe_no_lock`          – **deprecated, ignored.** Previously enabled
+///   `MDB_NOLOCK|MDB_NOSYNC|MDB_NOMETASYNC` for LMDB; benchmarks showed no
+///   measurable win under realistic contention, so the flag is now a no-op.
+///   The parameter remains in the signature for ABI compatibility and will be
+///   removed in a future release.
 /// * `enable_mmap_cache`           – pre-populate mmap caches after the initial scan
 /// * `enable_content_indexing`     – build content index after the initial scan
 /// * `watch`                       – start a background file-system watcher for live updates
@@ -177,7 +184,7 @@ pub unsafe extern "C" fn fff_create_instance2(
     base_path: *const c_char,
     frecency_db_path: *const c_char,
     history_db_path: *const c_char,
-    use_unsafe_no_lock: bool,
+    _use_unsafe_no_lock: bool,
     enable_mmap_cache: bool,
     enable_content_indexing: bool,
     watch: bool,
@@ -214,12 +221,12 @@ pub unsafe extern "C" fn fff_create_instance2(
             let _ = std::fs::create_dir_all(parent);
         }
 
-        match FrecencyTracker::new(frecency_path, use_unsafe_no_lock) {
+        match FrecencyTracker::open(frecency_path) {
             Ok(tracker) => {
                 if let Err(e) = shared_frecency.init(tracker) {
                     return FffResult::err(&format!("Failed to acquire frecency lock: {}", e));
                 }
-                let _ = shared_frecency.spawn_gc(frecency_path.clone(), use_unsafe_no_lock);
+                let _ = shared_frecency.spawn_gc(frecency_path.clone());
             }
             Err(e) => return FffResult::err(&format!("Failed to init frecency db: {}", e)),
         }
@@ -231,7 +238,7 @@ pub unsafe extern "C" fn fff_create_instance2(
             let _ = std::fs::create_dir_all(parent);
         }
 
-        match QueryTracker::new(history_path, use_unsafe_no_lock) {
+        match QueryTracker::open(history_path) {
             Ok(tracker) => {
                 if let Err(e) = query_tracker.init(tracker) {
                     return FffResult::err(&format!("Failed to acquire query tracker lock: {}", e));

--- a/crates/fff-core/src/frecency.rs
+++ b/crates/fff-core/src/frecency.rs
@@ -2,12 +2,10 @@ use crate::db_healthcheck::DbHealthChecker;
 use crate::error::{Error, Result};
 use crate::file_picker::FFFMode;
 use crate::git::is_modified_status;
+use crate::lmdb::{LmdbStore, is_map_full};
 use crate::shared::SharedFrecency;
-use heed::{Database, Env, EnvOpenOptions};
-use heed::{
-    EnvFlags,
-    types::{Bytes, SerdeBincode},
-};
+use heed::types::{Bytes, SerdeBincode};
+use heed::{Database, Env};
 use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -16,6 +14,7 @@ use std::{collections::VecDeque, path::Path};
 const DECAY_CONSTANT: f64 = 0.0693; // ln(2)/10 for 10-day half-life
 const SECONDS_PER_DAY: f64 = 86400.0;
 const MAX_HISTORY_DAYS: f64 = 30.0; // Only consider accesses within 30 days
+const MAX_TIMESTAMPS_PER_FILE: usize = 128;
 
 // AI mode: faster decay since AI sessions are shorter and more intense
 const AI_DECAY_CONSTANT: f64 = 0.231; // ln(2)/3 for 3-day half-life
@@ -57,26 +56,25 @@ impl DbHealthChecker for FrecencyTracker {
     }
 }
 
+impl LmdbStore for FrecencyTracker {
+    const MAX_DBS: u32 = 0;
+    // 10 MiB hard ceiling. Owner's db after years of use is ~560 KiB, so this
+    // leaves ~18× headroom while capping runaway growth (see GH issue #437).
+    const MAP_SIZE: usize = 10 * 1024 * 1024;
+    // Nuke the db when it exceeds 8 MiB on disk — leaves a small margin under
+    // MAP_SIZE so we don't hit MDB_MAP_FULL before the open-time erase fires.
+    const SIZE_CAP_BYTES: u64 = 8 * 1024 * 1024;
+}
+
 impl FrecencyTracker {
     /// Returns the on-disk path of the LMDB environment directory.
     pub fn db_path(&self) -> &Path {
         self.env.path()
     }
 
-    pub fn new(db_path: impl AsRef<Path>, use_unsafe_no_lock: bool) -> Result<Self> {
+    pub fn open(db_path: impl AsRef<Path>) -> Result<Self> {
         let db_path = db_path.as_ref();
-        fs::create_dir_all(db_path).map_err(Error::CreateDir)?;
-
-        let env = unsafe {
-            let mut opts = EnvOpenOptions::new();
-            opts.map_size(24 * 1024 * 1024); // 24 MiB
-            if use_unsafe_no_lock {
-                opts.flags(EnvFlags::NO_LOCK | EnvFlags::NO_SYNC | EnvFlags::NO_META_SYNC);
-            }
-            opts.open(db_path).map_err(Error::EnvOpen)?
-        };
-        env.clear_stale_readers()
-            .map_err(Error::DbClearStaleReaders)?;
+        let env = Self::open_env(db_path)?;
 
         // Try read-only open first — avoids blocking on the LMDB write lock
         // when another process (Neovim, another fff-mcp) already has it.
@@ -101,10 +99,16 @@ impl FrecencyTracker {
             }
         };
 
-        Ok(FrecencyTracker {
-            db,
-            env: env.clone(),
-        })
+        Ok(FrecencyTracker { db, env })
+    }
+
+    #[deprecated(
+        since = "0.7.0",
+        note = "LMDB unsafe no-lock mode is no longer supported; use `FrecencyTracker::open` instead. \
+                The `_use_unsafe_no_lock` argument is ignored."
+    )]
+    pub fn new(db_path: impl AsRef<Path>, _use_unsafe_no_lock: bool) -> Result<Self> {
+        Self::open(db_path)
     }
 
     /// Spawns a background thread to purge stale frecency entries and compact the database.
@@ -116,26 +120,28 @@ impl FrecencyTracker {
     /// use fff_search::frecency::FrecencyTracker;
     /// use fff_search::SharedFrecency;
     /// let shared_frecency: SharedFrecency = Default::default();
-    /// let _ = FrecencyTracker::spawn_gc(shared_frecency, "/path/to/frecency_db".into(), true).ok();
+    /// let _ = FrecencyTracker::spawn_gc(shared_frecency, "/path/to/frecency_db".into()).ok();
     /// ```
     pub fn spawn_gc(
         shared: SharedFrecency,
         db_path: String,
-        use_unsafe_no_lock: bool,
     ) -> Result<std::thread::JoinHandle<()>> {
         Ok(std::thread::Builder::new()
             .name("fff-frecency-gc".into())
-            .spawn(move || Self::run_frecency_gc(shared, db_path, use_unsafe_no_lock))?)
+            .spawn(move || Self::run_frecency_gc(shared, db_path))?)
     }
 
     #[tracing::instrument(skip(shared), fields(db_path = %db_path))]
-    fn run_frecency_gc(shared: SharedFrecency, db_path: String, use_unsafe_no_lock: bool) {
+    fn run_frecency_gc(shared: SharedFrecency, db_path: String) {
         let start = std::time::Instant::now();
-        let data_path = PathBuf::from(&db_path).join("data.mdb");
 
-        // Phase 1: Purge stale entries.
-        // The RwLock protects the Option<FrecencyTracker> (not the DB itself),
-        // so a read lock is sufficient — LMDB handles its own write serialization.
+        // Purge stale entries under a read lock on the Rust `Option`. LMDB
+        // serialises the internal write txn itself, so cross-process contention
+        // is handled below the heed layer. In-place compaction is intentionally
+        // skipped: it would require deleting `data.mdb`/`lock.mdb` while other
+        // processes may still hold the env, risking a split-brain on the same
+        // inode. Oversize reclamation happens at open time via
+        // `LmdbStore::erase_if_oversized` instead.
         let (deleted, pruned) = {
             let guard = match shared.read() {
                 Ok(g) => g,
@@ -160,97 +166,14 @@ impl FrecencyTracker {
             tracing::info!(deleted, pruned, elapsed = ?start.elapsed(), "Frecency GC purged entries");
         }
 
-        // Compact if we purged entries OR the file has significant freelist bloat
+        let data_path = PathBuf::from(&db_path).join("data.mdb");
         let file_size = fs::metadata(&data_path).map(|m| m.len()).unwrap_or(0);
-        if deleted == 0 && pruned == 0 && file_size <= 512 * 1024 {
-            return;
-        }
-
-        // Phase 2: Manual compaction under a single write lock
-        let mut guard = match shared.write() {
-            Ok(g) => g,
-            Err(e) => {
-                tracing::debug!("Failed to acquire write lock: {e}");
-                return;
-            }
-        };
-
-        // Read all entries from current env
-        let entries: Vec<(Vec<u8>, VecDeque<u64>)> = match guard.as_ref() {
-            Some(tracker) => {
-                let rtxn = match tracker.env.read_txn() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        tracing::debug!("Compaction read_txn failed: {e}");
-                        return;
-                    }
-                };
-                let iter = match tracker.db.iter(&rtxn) {
-                    Ok(i) => i,
-                    Err(e) => {
-                        tracing::debug!("Compaction iter failed: {e}");
-                        return;
-                    }
-                };
-                let mut entries = Vec::new();
-                let mut read_errors = 0u32;
-                for result in iter {
-                    match result {
-                        Ok((key, value)) => entries.push((key.to_vec(), value)),
-                        Err(_) => read_errors += 1,
-                    }
-                }
-                if read_errors > 0 {
-                    tracing::warn!(
-                        read_errors,
-                        "Skipped corrupted entries during compaction read"
-                    );
-                }
-                entries
-            }
-            None => return,
-        };
-
-        // Drop old tracker, delete files, create fresh env, write back
-        *guard = None;
-
-        let lock_path = PathBuf::from(&db_path).join("lock.mdb");
-        let _ = fs::remove_file(&data_path);
-        let _ = fs::remove_file(&lock_path);
-
-        let tracker = match FrecencyTracker::new(&db_path, use_unsafe_no_lock) {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!("Compaction reopen failed, frecency disabled: {e}");
-                return;
-            }
-        };
-
-        let write_result = (|| -> std::result::Result<(), heed::Error> {
-            let mut wtxn = tracker.env.write_txn()?;
-            for (key, value) in &entries {
-                tracker.db.put(&mut wtxn, key.as_slice(), value)?;
-            }
-            wtxn.commit()?;
-            Ok(())
-        })();
-
-        match write_result {
-            Ok(()) => {
-                let new_size = fs::metadata(&data_path).map(|m| m.len()).unwrap_or(0);
-                *guard = Some(tracker);
-                tracing::debug!(
-                    entries = entries.len(),
-                    old_size = file_size,
-                    new_size,
-                    elapsed = ?start.elapsed(),
-                    "Frecency DB compacted"
-                );
-            }
-            Err(e) => {
-                tracing::error!("Compaction write failed, frecency data may be incomplete: {e}");
-                *guard = Some(tracker);
-            }
+        if file_size > <Self as LmdbStore>::SIZE_CAP_BYTES {
+            tracing::warn!(
+                size = file_size,
+                cap = <Self as LmdbStore>::SIZE_CAP_BYTES,
+                "Frecency DB exceeds size cap — will be erased on next open"
+            );
         }
     }
 
@@ -347,8 +270,11 @@ impl FrecencyTracker {
 
         let now = self.get_now();
         let cutoff_time = now.saturating_sub((MAX_HISTORY_DAYS * SECONDS_PER_DAY) as u64);
+
+        // Drop stale timestamps from the front while also enforcing the
+        // per-file cap. Reserves one slot for the `push_back` below.
         while let Some(&front_time) = accesses.front() {
-            if front_time < cutoff_time {
+            if front_time < cutoff_time || accesses.len() >= MAX_TIMESTAMPS_PER_FILE {
                 accesses.pop_front();
             } else {
                 break;
@@ -358,11 +284,28 @@ impl FrecencyTracker {
         accesses.push_back(now);
         tracing::debug!(?path, accesses = accesses.len(), "Tracking access");
 
-        self.db
-            .put(&mut wtxn, &key_hash, &accesses)
-            .map_err(Error::DbWrite)?;
+        if let Err(e) = self.db.put(&mut wtxn, &key_hash, &accesses) {
+            if is_map_full(&e) {
+                tracing::error!(
+                    ?path,
+                    "Frecency DB hit MDB_MAP_FULL; dropping write — db will be \
+                     erased on next open via LmdbStore::erase_if_oversized"
+                );
+                return Ok(());
+            }
+            return Err(Error::DbWrite(e));
+        }
 
-        wtxn.commit().map_err(Error::DbCommit)?;
+        if let Err(e) = wtxn.commit() {
+            if is_map_full(&e) {
+                tracing::error!(
+                    ?path,
+                    "Frecency DB hit MDB_MAP_FULL on commit; dropping write"
+                );
+                return Ok(());
+            }
+            return Err(Error::DbCommit(e));
+        }
 
         Ok(())
     }
@@ -533,7 +476,7 @@ mod tests {
     fn test_modification_score_interpolation() {
         let temp_dir = std::env::temp_dir().join("fff_test_interpolation");
         let _ = std::fs::remove_dir_all(&temp_dir);
-        let tracker = FrecencyTracker::new(temp_dir.to_str().unwrap(), true).unwrap();
+        let tracker = FrecencyTracker::open(temp_dir.to_str().unwrap()).unwrap();
 
         let current_time = tracker.get_now();
         let git_status = Some(git2::Status::WT_MODIFIED);

--- a/crates/fff-core/src/lib.rs
+++ b/crates/fff-core/src/lib.rs
@@ -44,10 +44,10 @@
 //! std::fs::create_dir_all(&tmp).unwrap();
 //!
 //! // 1. Optionally initialize frecency and query tracker databases
-//! let frecency = FrecencyTracker::new(tmp.join("frecency"), false)?;
+//! let frecency = FrecencyTracker::open(tmp.join("frecency"))?;
 //! shared_frecency.init(frecency)?;
 //!
-//! let query_tracker = QueryTracker::new(tmp.join("queries"), false)?;
+//! let query_tracker = QueryTracker::open(tmp.join("queries"))?;
 //! shared_query_tracker.init(query_tracker)?;
 //!
 //! // 2. Init the file picker (spawns background scan + watcher)
@@ -144,6 +144,7 @@ pub mod query_tracker;
 pub mod types;
 
 mod ignore;
+mod lmdb;
 /// Thread-safe shared handles for [`FilePicker`], [`FrecencyTracker`],
 /// and [`QueryTracker`].
 pub mod shared;

--- a/crates/fff-core/src/lmdb.rs
+++ b/crates/fff-core/src/lmdb.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::Path;
+
+use heed::{Env, EnvOpenOptions};
+
+use crate::error::{Error, Result};
+
+pub(crate) fn is_map_full(err: &heed::Error) -> bool {
+    matches!(err, heed::Error::Mdb(heed::MdbError::MapFull))
+}
+
+pub(crate) trait LmdbStore {
+    /// LMDB map size in bytes. Must be a multiple of the OS page size.
+    const MAP_SIZE: usize;
+    /// Number of named sub-databases. `0` for single-db envs.
+    const MAX_DBS: u32;
+    /// Hard cap on `data.mdb` size.
+    const SIZE_CAP_BYTES: u64;
+
+    #[tracing::instrument]
+    fn open_env(db_path: &Path) -> Result<Env> {
+        Self::erase_if_oversized(db_path);
+        fs::create_dir_all(db_path).map_err(Error::CreateDir)?;
+
+        let env = unsafe {
+            let mut opts = EnvOpenOptions::new();
+            opts.map_size(Self::MAP_SIZE);
+            if Self::MAX_DBS > 0 {
+                opts.max_dbs(Self::MAX_DBS);
+            }
+            opts.open(db_path).map_err(Error::EnvOpen)?
+        };
+
+        env.clear_stale_readers()
+            .map_err(Error::DbClearStaleReaders)?;
+
+        Ok(env)
+    }
+
+    fn erase_if_oversized(db_path: &Path) {
+        let data = db_path.join("data.mdb");
+        let Ok(meta) = fs::metadata(&data) else {
+            return;
+        };
+        if meta.len() <= Self::SIZE_CAP_BYTES {
+            return;
+        }
+
+        tracing::error!(
+            path = %db_path.display(),
+            size = meta.len(),
+            cap = Self::SIZE_CAP_BYTES,
+            "LMDB db exceeds size cap, erasing"
+        );
+        let _ = fs::remove_file(&data);
+        let _ = fs::remove_file(db_path.join("lock.mdb"));
+    }
+}

--- a/crates/fff-core/src/query_tracker.rs
+++ b/crates/fff-core/src/query_tracker.rs
@@ -1,11 +1,10 @@
 use crate::db_healthcheck::DbHealthChecker;
 use crate::error::Error;
-use heed::types::Bytes;
-use heed::{Database, Env, EnvOpenOptions};
-use heed::{EnvFlags, types::SerdeBincode};
+use crate::lmdb::{LmdbStore, is_map_full};
+use heed::types::{Bytes, SerdeBincode};
+use heed::{Database, Env};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -60,32 +59,27 @@ impl DbHealthChecker for QueryTracker {
     }
 }
 
+impl LmdbStore for QueryTracker {
+    // 10 MiB hard ceiling. Same reasoning as FrecencyTracker (GH issue #437).
+    const MAP_SIZE: usize = 10 * 1024 * 1024;
+    const MAX_DBS: u32 = 16;
+    // Nuke at 4 MiB — query history is bounded per-project but query→file
+    // associations grow unbounded over typing time.
+    const SIZE_CAP_BYTES: u64 = 4 * 1024 * 1024;
+}
+
 impl QueryTracker {
     /// Returns the on-disk path of the LMDB environment directory.
     pub fn db_path(&self) -> &Path {
         self.env.path()
     }
 
-    pub fn new(db_path: impl AsRef<Path>, use_unsafe_no_lock: bool) -> Result<Self, Error> {
+    pub fn open(db_path: impl AsRef<Path>) -> Result<Self, Error> {
         let db_path = db_path.as_ref();
-        fs::create_dir_all(db_path).map_err(Error::CreateDir)?;
-
-        let env = unsafe {
-            let mut opts = EnvOpenOptions::new();
-            opts.map_size(10 * 1024 * 1024); // 100 MiB
-            opts.max_dbs(16); // Allow up to 16 databases per environment
-            if use_unsafe_no_lock {
-                opts.flags(EnvFlags::NO_LOCK | EnvFlags::NO_SYNC | EnvFlags::NO_META_SYNC);
-            }
-            opts.open(db_path).map_err(Error::EnvOpen)?
-        };
-
-        env.clear_stale_readers()
-            .map_err(Error::DbClearStaleReaders)?;
+        let env = Self::open_env(db_path)?;
 
         let mut wtxn = env.write_txn().map_err(Error::DbStartWriteTxn)?;
 
-        // Create two named databases
         let query_file_db = env
             .create_database(&mut wtxn, Some("query_file_associations"))
             .map_err(Error::DbCreate)?;
@@ -104,6 +98,15 @@ impl QueryTracker {
             query_history_db,
             grep_query_history_db,
         })
+    }
+
+    #[deprecated(
+        since = "0.7.0",
+        note = "LMDB unsafe no-lock mode is no longer supported; use `QueryTracker::open` instead. \
+                The `_use_unsafe_no_lock` argument is ignored."
+    )]
+    pub fn new(db_path: impl AsRef<Path>, _use_unsafe_no_lock: bool) -> Result<Self, Error> {
+        Self::open(db_path)
     }
 
     fn get_now(&self) -> u64 {
@@ -230,15 +233,39 @@ impl QueryTracker {
 
         entry.last_opened = now;
 
-        self.query_file_db
-            .put(&mut wtxn, &query_key, &entry)
-            .map_err(Error::DbWrite)?;
+        if let Err(e) = self.query_file_db.put(&mut wtxn, &query_key, &entry) {
+            if is_map_full(&e) {
+                tracing::error!(
+                    ?query,
+                    "Query tracker DB hit MDB_MAP_FULL; dropping write — db will \
+                     be erased on next open"
+                );
+                return Ok(());
+            }
+            return Err(Error::DbWrite(e));
+        }
 
         // Update query history database
         let project_key = Self::create_project_key(project_path)?;
-        Self::append_to_history(&self.query_history_db, &mut wtxn, &project_key, query, now)?;
+        if let Err(e) =
+            Self::append_to_history(&self.query_history_db, &mut wtxn, &project_key, query, now)
+        {
+            if let Error::DbWrite(ref inner) = e
+                && is_map_full(inner)
+            {
+                tracing::error!(?query, "Query tracker DB map full while appending history");
+                return Ok(());
+            }
+            return Err(e);
+        }
 
-        wtxn.commit().map_err(Error::DbCommit)?;
+        if let Err(e) = wtxn.commit() {
+            if is_map_full(&e) {
+                tracing::error!(?query, "Query tracker DB map full on commit");
+                return Ok(());
+            }
+            return Err(Error::DbCommit(e));
+        }
 
         tracing::debug!(?query, ?file_path, "Tracked query completion");
         Ok(())
@@ -307,15 +334,29 @@ impl QueryTracker {
         let project_key = Self::create_project_key(project_path)?;
         let mut wtxn = self.env.write_txn().map_err(Error::DbStartWriteTxn)?;
 
-        Self::append_to_history(
+        if let Err(e) = Self::append_to_history(
             &self.grep_query_history_db,
             &mut wtxn,
             &project_key,
             query,
             now,
-        )?;
+        ) {
+            if let Error::DbWrite(ref inner) = e
+                && is_map_full(inner)
+            {
+                tracing::error!(?query, "Grep query history DB map full; dropping write");
+                return Ok(());
+            }
+            return Err(e);
+        }
 
-        wtxn.commit().map_err(Error::DbCommit)?;
+        if let Err(e) = wtxn.commit() {
+            if is_map_full(&e) {
+                tracing::error!(?query, "Grep query history DB map full on commit");
+                return Ok(());
+            }
+            return Err(Error::DbCommit(e));
+        }
 
         tracing::debug!(?query, "Tracked grep query");
         Ok(())
@@ -343,7 +384,7 @@ mod tests {
         let temp_dir = env::temp_dir().join("fff_test_query_tracking_new");
         let _ = std::fs::remove_dir_all(&temp_dir);
 
-        let mut tracker = QueryTracker::new(temp_dir.to_str().unwrap(), true).unwrap();
+        let mut tracker = QueryTracker::open(temp_dir.to_str().unwrap()).unwrap();
 
         let project_path = PathBuf::from("/test/project");
         let file_path = PathBuf::from("/test/project/src/main.rs");

--- a/crates/fff-core/src/shared.rs
+++ b/crates/fff-core/src/shared.rs
@@ -282,12 +282,8 @@ impl SharedFrecency {
     }
 
     /// Spawn a background GC thread for this frecency tracker.
-    pub fn spawn_gc(
-        &self,
-        db_path: String,
-        use_unsafe_no_lock: bool,
-    ) -> crate::Result<std::thread::JoinHandle<()>> {
-        FrecencyTracker::spawn_gc(self.clone(), db_path, use_unsafe_no_lock)
+    pub fn spawn_gc(&self, db_path: String) -> crate::Result<std::thread::JoinHandle<()>> {
+        FrecencyTracker::spawn_gc(self.clone(), db_path)
     }
 
     /// Drop the in-memory tracker and delete the on-disk database directory.

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -235,10 +235,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let shared_picker = SharedFilePicker::default();
     let shared_frecency = SharedFrecency::default();
     if let Some(frecency_db_path) = args.frecency_db_path {
-        match FrecencyTracker::new(&frecency_db_path, false) {
+        match FrecencyTracker::open(&frecency_db_path) {
             Ok(tracker) => {
                 let _ = shared_frecency.init(tracker);
-                let _ = shared_frecency.spawn_gc(frecency_db_path, false);
+                let _ = shared_frecency.spawn_gc(frecency_db_path);
             }
             Err(e) => {
                 eprintln!("Warning: Failed to init frecency db: {}", e);

--- a/crates/fff-nvim/Cargo.toml
+++ b/crates/fff-nvim/Cargo.toml
@@ -51,6 +51,10 @@ path = "src/bin/test_memory_leak.rs"
 name = "bench_ci_memmem"
 path = "src/bin/bench_ci_memmem.rs"
 
+[[bin]]
+name = "bench_lmdb_parallel"
+path = "src/bin/bench_lmdb_parallel.rs"
+
 [dependencies]
 # Workspace dependencies
 ahash = { workspace = true }

--- a/crates/fff-nvim/benches/query_tracker_bench.rs
+++ b/crates/fff-nvim/benches/query_tracker_bench.rs
@@ -103,7 +103,7 @@ fn setup_tracker_with_data(entries: &[TestQueryEntry]) -> (QueryTracker, PathBuf
         .as_nanos();
     let temp_dir =
         std::env::temp_dir().join(format!("fff_bench_{}_{}", timestamp, rand::random::<u32>()));
-    let mut tracker = QueryTracker::new(temp_dir.to_str().unwrap(), true).unwrap();
+    let mut tracker = QueryTracker::open(temp_dir.to_str().unwrap()).unwrap();
 
     // Insert all test data
     for entry in entries {

--- a/crates/fff-nvim/src/bin/bench_lmdb_parallel.rs
+++ b/crates/fff-nvim/src/bin/bench_lmdb_parallel.rs
@@ -1,0 +1,150 @@
+/// Parallel LMDB contention bench.
+///
+/// Spawns N child processes that all open the same frecency + query-tracker
+/// dbs and hammer them. Used to measure the cost (or absence of cost) of
+/// dropping the `MDB_NOLOCK | NO_SYNC | NO_META_SYNC` env flags.
+///
+/// Usage:
+///   cargo build --release --bin bench_lmdb_parallel
+///   ./target/release/bench_lmdb_parallel --procs 4 --iters 5000
+///
+/// Env var FFF_BENCH_ROLE=worker turns the binary into a worker that talks
+/// to a db path passed via FFF_BENCH_DB.
+use fff::frecency::FrecencyTracker;
+use fff::query_tracker::QueryTracker;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+fn parse_args() -> (usize, usize, Option<String>) {
+    let mut procs = 4usize;
+    let mut iters = 2000usize;
+    let mut db_path: Option<String> = None;
+    let mut args = env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--procs" => procs = args.next().and_then(|s| s.parse().ok()).unwrap_or(procs),
+            "--iters" => iters = args.next().and_then(|s| s.parse().ok()).unwrap_or(iters),
+            "--db" => db_path = args.next(),
+            _ => {}
+        }
+    }
+    (procs, iters, db_path)
+}
+
+fn worker_main(db: &Path, iters: usize, worker_id: u32) {
+    let frecency_path = db.join("frecency");
+    let history_path = db.join("history");
+
+    let frecency = FrecencyTracker::open(&frecency_path).expect("frecency open");
+    let mut query_tracker = QueryTracker::open(&history_path).expect("query tracker open");
+
+    let project = PathBuf::from("/bench/project");
+    let started = Instant::now();
+
+    for i in 0..iters {
+        let file = PathBuf::from(format!(
+            "/bench/project/src/file_{}_{}.rs",
+            worker_id,
+            i % 256
+        ));
+        // Frecency write path — same call as track_access on BufEnter.
+        frecency.track_access(&file).expect("frecency track_access");
+
+        // Query tracker write path — same as track_query_completion on file open.
+        let query = format!("q{}", i % 32);
+        query_tracker
+            .track_query_completion(&query, &project, &file)
+            .expect("query tracker track_query_completion");
+
+        // A read every few iterations.
+        if i % 8 == 0 {
+            let _ = frecency.seconds_since_last_access(&file).ok();
+            let _ = query_tracker
+                .get_historical_query(&project, 0)
+                .ok()
+                .flatten();
+        }
+    }
+
+    let elapsed = started.elapsed();
+    eprintln!(
+        "worker {} done: {} iters in {:?} ({:.0} ops/s)",
+        worker_id,
+        iters,
+        elapsed,
+        iters as f64 * 3.0 / elapsed.as_secs_f64()
+    );
+}
+
+fn driver_main(procs: usize, iters: usize, db_override: Option<String>) {
+    let db = db_override.map(PathBuf::from).unwrap_or_else(|| {
+        std::env::temp_dir().join(format!("fff_bench_lmdb_{}", std::process::id()))
+    });
+    let _ = std::fs::remove_dir_all(&db);
+    std::fs::create_dir_all(&db).expect("create db dir");
+
+    let exe = env::current_exe().expect("current_exe");
+
+    eprintln!(
+        "driver: launching {} workers, {} iters each, db={}",
+        procs,
+        iters,
+        db.display()
+    );
+
+    let started = Instant::now();
+    let mut children = Vec::with_capacity(procs);
+    for worker_id in 0..procs {
+        let child = Command::new(&exe)
+            .env("FFF_BENCH_ROLE", "worker")
+            .env("FFF_BENCH_DB", &db)
+            .env("FFF_BENCH_ITERS", iters.to_string())
+            .env("FFF_BENCH_WORKER_ID", worker_id.to_string())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn worker");
+        children.push(child);
+    }
+
+    let mut failures = 0u32;
+    for mut child in children {
+        let status = child.wait().expect("wait");
+        if !status.success() {
+            failures += 1;
+        }
+    }
+
+    let elapsed = started.elapsed();
+    let total_ops = procs as f64 * iters as f64 * 3.0;
+    eprintln!(
+        "driver: all workers done in {:?}, ~{:.0} ops/s aggregate, failures={}",
+        elapsed,
+        total_ops / elapsed.as_secs_f64(),
+        failures
+    );
+
+    let _ = std::fs::remove_dir_all(&db);
+}
+
+fn main() {
+    // Worker branch: spawned by driver to contend on the same db.
+    if env::var("FFF_BENCH_ROLE").as_deref() == Ok("worker") {
+        let db = env::var("FFF_BENCH_DB").expect("FFF_BENCH_DB");
+        let iters: usize = env::var("FFF_BENCH_ITERS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000);
+        let worker_id: u32 = env::var("FFF_BENCH_WORKER_ID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        worker_main(Path::new(&db), iters, worker_id);
+        return;
+    }
+
+    let (procs, iters, db) = parse_args();
+    driver_main(procs, iters, db);
+}

--- a/crates/fff-nvim/src/lib.rs
+++ b/crates/fff-nvim/src/lib.rs
@@ -33,27 +33,25 @@ pub static QUERY_TRACKER: Lazy<SharedQueryTracker> = Lazy::new(SharedQueryTracke
 
 pub fn init_db(
     _: &Lua,
-    (frecency_db_path, history_db_path, use_unsafe_no_lock): (String, String, bool),
+    (frecency_db_path, history_db_path, _use_unsafe_no_lock): (String, String, bool),
 ) -> LuaResult<bool> {
     let mut frecency = FRECENCY.write().into_lua_result()?;
     if frecency.is_some() {
         *frecency = None;
     }
-    *frecency =
-        Some(FrecencyTracker::new(&frecency_db_path, use_unsafe_no_lock).into_lua_result()?);
+    *frecency = Some(FrecencyTracker::open(&frecency_db_path).into_lua_result()?);
     tracing::info!("Frecency database initialized at {}", frecency_db_path);
     drop(frecency);
 
     // Spawn background GC to purge stale entries without blocking startup
-    let _ = FRECENCY.spawn_gc(frecency_db_path, use_unsafe_no_lock);
+    let _ = FRECENCY.spawn_gc(frecency_db_path);
 
     let mut query_tracker = QUERY_TRACKER.write().into_lua_result()?;
     if query_tracker.is_some() {
         *query_tracker = None;
     }
 
-    *query_tracker =
-        Some(QueryTracker::new(&history_db_path, use_unsafe_no_lock).into_lua_result()?);
+    *query_tracker = Some(QueryTracker::open(&history_db_path).into_lua_result()?);
 
     tracing::info!("Query tracker database initialized at {}", history_db_path);
     Ok(true)

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 02
+                              For Neovim >= 0.10.0    Last change: 2026 May 03
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*


### PR DESCRIPTION
Adds runaway-growth safeguards (closes https://github.com/dmtrKovalenko/fff/issues/437) report of multi-GB frecency
cache. Deprecates the old unsafe_no_lock mode.

should also fix https://github.com/dmtrKovalenko/fff/issues/434 (but I am not sure)