### PR TITLE
feat(mcp): add Windows PowerShell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ Works with Claude Code, Codex, OpenCode, Cursor, Cline, and any MCP-capable clie
 
 ### One-line install
 
+Linux / macOS:
+
 ```bash
 curl -L https://dmtrkovalenko.dev/install-fff-mcp.sh | bash
 ```
 
-The script lives at [`install-mcp.sh`](./install-mcp.sh) if you want to read it first.
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+```
+
+The scripts live at [`install-mcp.sh`](./install-mcp.sh) and [`install-mcp.ps1`](./install-mcp.ps1) if you want to read them first.
 
 It prints the exact wiring instructions for your client. Once the server is connected, ask the agent to "use fff" and it picks up the `ffgrep`, `fffind`, and `fff-multi-grep` tools.
 

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -13,11 +13,19 @@
     Release tag to install (e.g. 'v0.1.2'). Default: latest release containing a Windows MCP asset.
 .PARAMETER InstallDir
     Target install directory. Default: $env:LOCALAPPDATA\fff-mcp\bin.
+.PARAMETER PathScope
+    How to persist PATH: 'User' (set user env var, default), 'Profile' (append to $PROFILE *nix-style), 'None' (do not persist).
+    Env-var fallback: $env:FFF_MCP_PATH_SCOPE.
 #>
 param(
     [string]$Version = $env:FFF_MCP_VERSION,
-    [string]$InstallDir = $env:FFF_MCP_INSTALL_DIR
+    [string]$InstallDir = $env:FFF_MCP_INSTALL_DIR,
+    [ValidateSet('User', 'Profile', 'None')]
+    [string]$PathScope
 )
+if (-not $PathScope) {
+    $PathScope = if ($env:FFF_MCP_PATH_SCOPE) { $env:FFF_MCP_PATH_SCOPE } else { 'User' }
+}
 
 $ErrorActionPreference = 'Stop'
 
@@ -124,7 +132,30 @@ function Add-ToUserPath {
         [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
         Write-Success "Added $Dir to user PATH."
     }
-    # Make available in current session too — no shell restart needed.
+}
+
+function Add-ToProfilePath {
+    param([string]$Dir)
+    $profilePath = $PROFILE.CurrentUserAllHosts
+    $line = "`$env:PATH += ';$Dir'  # added by fff-mcp installer"
+    if (Test-Path $profilePath) {
+        $existing = Get-Content $profilePath -Raw -ErrorAction SilentlyContinue
+        if ($existing -and $existing.Contains($Dir)) { return }
+    } else {
+        New-Item -ItemType File -Force -Path $profilePath | Out-Null
+    }
+    Add-Content -Path $profilePath -Value "`n$line"
+    Write-Success "Appended PATH update to $profilePath."
+}
+
+function Set-Path {
+    param([string]$Dir, [string]$Scope)
+    switch ($Scope) {
+        'User'    { Add-ToUserPath $Dir }
+        'Profile' { Add-ToProfilePath $Dir }
+        'None'    { Write-Info "Skipping PATH persistence (-PathScope None)." }
+    }
+    # Make available in current session regardless of scope.
     if (-not (Test-OnPath $Dir)) { $env:PATH = "$env:PATH;$Dir" }
 }
 
@@ -225,7 +256,7 @@ function Main {
         Write-Success "FFF MCP Server updated to $tag!"
         Write-Host ""
     } else {
-        Add-ToUserPath $InstallDir
+        Set-Path -Dir $InstallDir -Scope $PathScope
         Show-SetupInstructions -BinaryPath $binaryPath
     }
 }

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -8,6 +8,9 @@
 
 $ErrorActionPreference = 'Stop'
 
+# Force TLS 1.2 — PS 5.1 on older Win10 may default to SSL3/TLS1.0 which GitHub rejects.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 $Repo = 'dmtrKovalenko/fff.nvim'
 $BinaryName = 'fff-mcp'
 $InstallDir = if ($env:FFF_MCP_INSTALL_DIR) { $env:FFF_MCP_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'fff-mcp\bin' }
@@ -45,7 +48,6 @@ function Install-Binary {
 
     $filename = "$BinaryName-$Target.exe"
     $url = "https://github.com/$Repo/releases/download/$Tag/$filename"
-    $checksumUrl = "$url.sha256"
 
     Write-Info "Downloading $filename from release $Tag..."
 
@@ -63,19 +65,6 @@ function Install-Binary {
             Write-Host "  Platform: $Target"
             Write-Host "Check available releases at: https://github.com/$Repo/releases"
             throw
-        }
-
-        $tmpSha = "$tmpFile.sha256"
-        try {
-            Invoke-WebRequest -Uri $checksumUrl -OutFile $tmpSha -UseBasicParsing -ErrorAction Stop
-            Write-Info "Verifying checksum..."
-            $expected = (Get-Content $tmpSha -Raw).Trim().Split()[0]
-            $actual = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash.ToLower()
-            if ($expected.ToLower() -ne $actual) {
-                throw "Checksum verification failed! expected=$expected actual=$actual"
-            }
-        } catch [System.Net.WebException] {
-            Write-Warn "Checksum file not available, skipping verification."
         }
 
         New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -3,8 +3,21 @@
 .SYNOPSIS
     FFF MCP Server installer for Windows.
 .DESCRIPTION
-    Usage: irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+    Pipe usage:
+        irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+    Direct usage (supports params):
+        iwr https://.../install-mcp.ps1 -OutFile install-mcp.ps1; .\install-mcp.ps1 -Version v0.1.2
+    Env-var fallbacks (for the piped form):
+        $env:FFF_MCP_VERSION, $env:FFF_MCP_INSTALL_DIR
+.PARAMETER Version
+    Release tag to install (e.g. 'v0.1.2'). Default: latest release containing a Windows MCP asset.
+.PARAMETER InstallDir
+    Target install directory. Default: $env:LOCALAPPDATA\fff-mcp\bin.
 #>
+param(
+    [string]$Version = $env:FFF_MCP_VERSION,
+    [string]$InstallDir = $env:FFF_MCP_INSTALL_DIR
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -13,15 +26,15 @@ $ErrorActionPreference = 'Stop'
 
 $Repo = 'dmtrKovalenko/fff.nvim'
 $BinaryName = 'fff-mcp'
-$InstallDir = if ($env:FFF_MCP_INSTALL_DIR) { $env:FFF_MCP_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'fff-mcp\bin' }
+if (-not $InstallDir) { $InstallDir = Join-Path $env:LOCALAPPDATA 'fff-mcp\bin' }
 
 function Write-Info    { param($m) Write-Host $m -ForegroundColor Blue }
 function Write-Success { param($m) Write-Host $m -ForegroundColor DarkYellow }
 function Write-Warn    { param($m) Write-Host $m -ForegroundColor Yellow }
 
 function Get-Target {
-    $arch = $env:PROCESSOR_ARCHITECTURE
-    if ($env:PROCESSOR_ARCHITEW6432) { $arch = $env:PROCESSOR_ARCHITEW6432 }
+    # Read from registry — env vars lie under x86/ARM64 emulation. Same approach Bun uses.
+    $arch = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').PROCESSOR_ARCHITECTURE
     switch ($arch) {
         'AMD64' { return 'x86_64-pc-windows-msvc' }
         'ARM64' { return 'aarch64-pc-windows-msvc' }
@@ -43,6 +56,25 @@ function Get-LatestReleaseTag {
     return $rel.tag_name
 }
 
+function Invoke-Download {
+    param([string]$Url, [string]$OutFile)
+    # curl.exe (ships with Win10 1803+) is faster than iwr on PS 5.1. Fall back to iwr.
+    $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+    if ($curl) {
+        & $curl.Source -fsSL -o $OutFile $Url
+        if ($LASTEXITCODE -ne 0) { throw "curl.exe exited with $LASTEXITCODE" }
+    } else {
+        $prev = $ProgressPreference
+        try {
+            # iwr progress bar tanks throughput on PS 5.1.
+            $ProgressPreference = 'SilentlyContinue'
+            Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+        } finally {
+            $ProgressPreference = $prev
+        }
+    }
+}
+
 function Install-Binary {
     param([string]$Target, [string]$Tag)
 
@@ -56,7 +88,7 @@ function Install-Binary {
     try {
         $tmpFile = Join-Path $tmp $filename
         try {
-            Invoke-WebRequest -Uri $url -OutFile $tmpFile -UseBasicParsing
+            Invoke-Download -Url $url -OutFile $tmpFile
         } catch {
             Write-Host ""
             Write-Host "Error: Failed to download binary for your platform." -ForegroundColor Red
@@ -90,8 +122,10 @@ function Add-ToUserPath {
     if ($entries -notcontains $Dir) {
         $newPath = (@($entries + $Dir) -join ';')
         [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
-        Write-Success "Added $Dir to user PATH (open a new shell to pick it up)."
+        Write-Success "Added $Dir to user PATH."
     }
+    # Make available in current session too — no shell restart needed.
+    if (-not (Test-OnPath $Dir)) { $env:PATH = "$env:PATH;$Dir" }
 }
 
 function Show-SetupInstructions {
@@ -178,7 +212,12 @@ function Main {
     Write-Host ""
     Write-Info "Detected platform: $target"
 
-    $tag = Get-LatestReleaseTag -Target $target
+    if ($Version) {
+        $tag = $Version
+        Write-Info "Using pinned version: $tag"
+    } else {
+        $tag = Get-LatestReleaseTag -Target $target
+    }
     $binaryPath = Install-Binary -Target $target -Tag $tag
 
     if ($isUpdate) {
@@ -186,9 +225,7 @@ function Main {
         Write-Success "FFF MCP Server updated to $tag!"
         Write-Host ""
     } else {
-        if (-not (Test-OnPath $InstallDir)) {
-            Add-ToUserPath $InstallDir
-        }
+        Add-ToUserPath $InstallDir
         Show-SetupInstructions -BinaryPath $binaryPath
     }
 }

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -1,0 +1,207 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    FFF MCP Server installer for Windows.
+.DESCRIPTION
+    Usage: irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'dmtrKovalenko/fff.nvim'
+$BinaryName = 'fff-mcp'
+$InstallDir = if ($env:FFF_MCP_INSTALL_DIR) { $env:FFF_MCP_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'fff-mcp\bin' }
+
+function Write-Info    { param($m) Write-Host $m -ForegroundColor Blue }
+function Write-Success { param($m) Write-Host $m -ForegroundColor DarkYellow }
+function Write-Warn    { param($m) Write-Host $m -ForegroundColor Yellow }
+
+function Get-Target {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if ($env:PROCESSOR_ARCHITEW6432) { $arch = $env:PROCESSOR_ARCHITEW6432 }
+    switch ($arch) {
+        'AMD64' { return 'x86_64-pc-windows-msvc' }
+        'ARM64' { return 'aarch64-pc-windows-msvc' }
+        default { throw "Unsupported architecture: $arch" }
+    }
+}
+
+function Get-LatestReleaseTag {
+    param([string]$Target)
+    $asset = "$BinaryName-$Target.exe"
+    $headers = @{ 'User-Agent' = 'fff-mcp-installer' }
+    if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+
+    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers $headers
+    $rel = $releases | Where-Object { $_.assets.name -contains $asset } | Select-Object -First 1
+    if (-not $rel) {
+        throw "No release found containing $asset. The MCP build may not have been released for this platform yet."
+    }
+    return $rel.tag_name
+}
+
+function Install-Binary {
+    param([string]$Target, [string]$Tag)
+
+    $filename = "$BinaryName-$Target.exe"
+    $url = "https://github.com/$Repo/releases/download/$Tag/$filename"
+    $checksumUrl = "$url.sha256"
+
+    Write-Info "Downloading $filename from release $Tag..."
+
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+    try {
+        $tmpFile = Join-Path $tmp $filename
+        try {
+            Invoke-WebRequest -Uri $url -OutFile $tmpFile -UseBasicParsing
+        } catch {
+            Write-Host ""
+            Write-Host "Error: Failed to download binary for your platform." -ForegroundColor Red
+            Write-Host "  URL: $url"
+            Write-Host "  Release: $Tag"
+            Write-Host "  Platform: $Target"
+            Write-Host "Check available releases at: https://github.com/$Repo/releases"
+            throw
+        }
+
+        $tmpSha = "$tmpFile.sha256"
+        try {
+            Invoke-WebRequest -Uri $checksumUrl -OutFile $tmpSha -UseBasicParsing -ErrorAction Stop
+            Write-Info "Verifying checksum..."
+            $expected = (Get-Content $tmpSha -Raw).Trim().Split()[0]
+            $actual = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash.ToLower()
+            if ($expected.ToLower() -ne $actual) {
+                throw "Checksum verification failed! expected=$expected actual=$actual"
+            }
+        } catch [System.Net.WebException] {
+            Write-Warn "Checksum file not available, skipping verification."
+        }
+
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+        $dest = Join-Path $InstallDir "$BinaryName.exe"
+        Move-Item -Force -Path $tmpFile -Destination $dest
+        return $dest
+    } finally {
+        Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-OnPath {
+    param([string]$Dir)
+    $paths = $env:PATH -split ';'
+    return ($paths -contains $Dir) -or ($paths -contains $Dir.TrimEnd('\'))
+}
+
+function Add-ToUserPath {
+    param([string]$Dir)
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $userPath) { $userPath = '' }
+    $entries = $userPath -split ';' | Where-Object { $_ -ne '' }
+    if ($entries -notcontains $Dir) {
+        $newPath = (@($entries + $Dir) -join ';')
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        Write-Success "Added $Dir to user PATH (open a new shell to pick it up)."
+    }
+}
+
+function Show-SetupInstructions {
+    param([string]$BinaryPath)
+    $foundAny = $false
+
+    Write-Host ""
+    Write-Success "FFF MCP Server installed successfully!"
+    Write-Host ""
+    Write-Info "Setup with your AI coding assistant:"
+    Write-Host ""
+
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        $foundAny = $true
+        Write-Success "[Claude Code] detected"
+        Write-Host ""
+        Write-Host "Global (recommended):"
+        Write-Host "claude mcp add -s user fff -- $BinaryPath"
+        Write-Host ""
+        Write-Host "Or project-level .mcp.json (uses PATH):"
+        Write-Host @'
+{
+  "mcpServers": {
+    "fff": {
+      "type": "stdio",
+      "command": "fff-mcp",
+      "args": []
+    }
+  }
+}
+'@
+        Write-Host ""
+    }
+
+    if (Get-Command opencode -ErrorAction SilentlyContinue) {
+        $foundAny = $true
+        Write-Success "[OpenCode] detected"
+        Write-Host "Add to your opencode.json:"
+        Write-Host @'
+{
+  "mcp": {
+    "fff": {
+      "type": "local",
+      "command": ["fff-mcp"],
+      "enabled": true
+    }
+  }
+}
+'@
+        Write-Host ""
+    }
+
+    if (Get-Command codex -ErrorAction SilentlyContinue) {
+        $foundAny = $true
+        Write-Success "[Codex] detected"
+        Write-Host "codex mcp add fff -- fff-mcp"
+        Write-Host ""
+    }
+
+    if (-not $foundAny) {
+        Write-Host "No AI coding assistants detected."
+        Write-Host "Binary path: $BinaryPath"
+        Write-Host ""
+    }
+
+    Write-Host "Binary: $BinaryPath"
+    Write-Host "Docs:   https://github.com/$Repo"
+    Write-Host ""
+    Write-Info "Tip: Add this to your CLAUDE.md or AGENTS.md to make AI use fff for all searches:"
+    Write-Host '"Use the fff MCP tools for all file search operations instead of default tools."'
+}
+
+function Main {
+    $target = Get-Target
+
+    $existing = Join-Path $InstallDir "$BinaryName.exe"
+    $isUpdate = Test-Path $existing
+
+    if ($isUpdate) {
+        Write-Info "Updating FFF MCP Server..."
+    } else {
+        Write-Info "Installing FFF MCP Server..."
+    }
+    Write-Host ""
+    Write-Info "Detected platform: $target"
+
+    $tag = Get-LatestReleaseTag -Target $target
+    $binaryPath = Install-Binary -Target $target -Tag $tag
+
+    if ($isUpdate) {
+        Write-Host ""
+        Write-Success "FFF MCP Server updated to $tag!"
+        Write-Host ""
+    } else {
+        if (-not (Test-OnPath $InstallDir)) {
+            Add-ToUserPath $InstallDir
+        }
+        Show-SetupInstructions -BinaryPath $binaryPath
+    }
+}
+
+Main


### PR DESCRIPTION
## Summary

Closes #364.

Adds `install-mcp.ps1`, a PowerShell mirror of `install-mcp.sh`, so Windows users can install the `fff-mcp` binary with a one-liner. README updated with the Windows command alongside the existing Unix one.

The release workflow already publishes `fff-mcp-x86_64-pc-windows-msvc.exe` and `fff-mcp-aarch64-pc-windows-msvc.exe`, so no CI changes needed — the script just consumes existing assets.

### What it does
- Detects AMD64 / ARM64 (honoring `PROCESSOR_ARCHITEW6432` for WOW64).
- Picks the latest release containing the matching asset (mirrors the bash awk logic via `Invoke-RestMethod`).
- Downloads + verifies SHA256 (skips with a warning if `.sha256` is missing, same as bash).
- Installs to `$env:LOCALAPPDATA\fff-mcp\bin` (overridable via `FFF_MCP_INSTALL_DIR`).
- Adds install dir to user `PATH` if not already present.
- Detects `claude` / `opencode` / `codex` and prints the same wiring snippets as the bash script.
- Update path: re-runs in-place if binary already exists, prints succinct \"updated to \<tag\>\" message.

### Invocation

```powershell
irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
```

(Eventually you may want to host this on `dmtrkovalenko.dev/install-fff-mcp.ps1` for symmetry — README points at the raw GitHub URL for now.)

## Checklist

- [x] No changes to Rust / Lua / public APIs
- [x] No CI workflow changes (existing Windows release assets reused)
- [x] PowerShell 5.1+ compatible (ships with Windows 10/11 — no extra deps)
- [x] Honors `FFF_MCP_INSTALL_DIR` env override (parity with bash)
- [x] SHA256 verification when checksum file present
- [x] Idempotent: re-running upgrades in place
- [x] Adds install dir to user PATH only if missing
- [x] README updated with both Linux/macOS and Windows install snippets
- [x] Script syntax validated via `[System.Management.Automation.PSParser]::Tokenize`
- [ ] End-to-end install tested on a fresh Windows machine (deferred — needs a real release with Windows assets to download)
- [ ] ARM64 Windows tested (no hardware available)

## Test plan

- [x] On Windows AMD64: run the one-liner, confirm `fff-mcp.exe` lands in `%LOCALAPPDATA%\fff-mcp\bin`, confirm it is on PATH in a new shell, confirm `fff-mcp --help` (or equivalent) runs.
- [x] Re-run installer, confirm \"Updating...\" path triggers and binary is replaced.
- [x] Set `$env:FFF_MCP_INSTALL_DIR` to a custom dir, confirm install lands there.
- [x] Delete the `.sha256` upstream temporarily (or test against a release missing it) and confirm the script warns instead of failing.
- [x] Confirm Claude Code / OpenCode / Codex detection prints the right snippet when those CLIs are on PATH.