### PR TITLE
feat: add wrap_around option for cursor navigation

### DIFF
--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -38,6 +38,7 @@ local M = {}
 --- @field send_to_quickfix string
 --- @field focus_list string
 --- @field focus_preview string
+--- @field wrap_around boolean
 
 --- @class FffFrecencyConfig
 --- @field enabled boolean
@@ -74,6 +75,7 @@ local M = {}
 --- @field git table
 --- @field debug table
 --- @field logging table
+--- @field wrap_around boolean
 --- @field file_picker table
 --- @field grep FffGrepConfig
 
@@ -199,6 +201,7 @@ local function init()
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
     prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
+    wrap_around = false, -- set to true to wrap cursor to the opposite end when reaching the first/last item
     layout = {
       height = 0.8,
       width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -38,7 +38,6 @@ local M = {}
 --- @field send_to_quickfix string
 --- @field focus_list string
 --- @field focus_preview string
---- @field wrap_around boolean
 
 --- @class FffFrecencyConfig
 --- @field enabled boolean

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2040,6 +2040,59 @@ function M.update_status(progress)
   })
 end
 
+--- Wrap cursor to the first page, first item (best result)
+function M.wrap_to_first()
+  if M.state.pagination.page_index == 0 then
+    -- Already on first page, just move cursor
+    M.state.cursor = 1
+    return true
+  end
+
+  -- For non-grep mode, jump directly to page 0
+  if M.state.mode ~= 'grep' then
+    return M.load_page_at_index(0, function()
+      M.state.cursor = 1
+    end)
+  end
+
+  -- For grep mode, we can only go back if page 0 offset is recorded
+  if M.state.pagination.grep_file_offsets[1] ~= nil then
+    return M.load_page_at_index(0, function()
+      M.state.cursor = 1
+    end)
+  end
+
+  M.state.cursor = 1
+  return true
+end
+
+--- Wrap cursor to the last page, last item (worst result)
+function M.wrap_to_last()
+  local page_size = M.state.pagination.page_size
+  if page_size == 0 then return false end
+
+  if M.state.mode ~= 'grep' then
+    local total = M.state.pagination.total_matched
+    if total == 0 then return false end
+    local max_page_index = math.max(0, math.ceil(total / page_size) - 1)
+
+    if M.state.pagination.page_index == max_page_index then
+      -- Already on last page, just move cursor to last item
+      M.state.cursor = #M.state.filtered_items
+      return true
+    end
+
+    return M.load_page_at_index(max_page_index, function(result_count)
+      M.state.cursor = result_count
+    end)
+  end
+
+  -- For grep mode, we can't jump to last page (sequential offsets required)
+  -- Just wrap within current page
+  M.state.cursor = #M.state.filtered_items
+  return true
+end
+
 function M.move_up()
   if not M.state.active then return end
   if #M.state.filtered_items == 0 then return end
@@ -2056,24 +2109,24 @@ function M.move_up()
     local at_last_item = M.state.cursor >= items_count
 
     if near_bottom and at_last_item then
-      -- Wrap around takes priority: at last item, jump to first
-      if wrap_around then
-        M.state.cursor = 1
-      else
-        local page_size = M.state.pagination.page_size
-        if page_size > 0 then
-          local has_more
-          if M.state.mode == 'grep' then
-            has_more = M.state.pagination.grep_next_file_offset > 0
-          else
-            local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
-            has_more = M.state.pagination.page_index < max_page
-          end
-          if has_more then
-            M.load_next_page()
-            return
-          end
+      local page_size = M.state.pagination.page_size
+      local has_more = false
+      if page_size > 0 then
+        if M.state.mode == 'grep' then
+          has_more = M.state.pagination.grep_next_file_offset > 0
+        else
+          local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
+          has_more = M.state.pagination.page_index < max_page
         end
+      end
+
+      if has_more then
+        -- More pages available: paginate normally
+        M.load_next_page()
+        return
+      elseif wrap_around then
+        -- At global end (last item on last page): wrap to first
+        M.wrap_to_first()
       end
     else
       M.state.cursor = math.min(M.state.cursor + 1, items_count)
@@ -2081,12 +2134,13 @@ function M.move_up()
   else
     -- Top prompt: scrolling UP means going to BETTER results (previous page)
     if M.state.cursor <= M.state.pagination.prefetch_margin + 1 and M.state.cursor <= 1 then
-      -- Wrap around takes priority: at first item, jump to last
-      if wrap_around then
-        M.state.cursor = items_count
-      elseif M.state.pagination.page_index > 0 then
+      if M.state.pagination.page_index > 0 then
+        -- More pages available: paginate normally
         vim.schedule(M.load_previous_page)
         return
+      elseif wrap_around then
+        -- At global start (first item on first page): wrap to last
+        M.wrap_to_last()
       end
     else
       M.state.cursor = math.max(M.state.cursor - 1, 1)
@@ -2127,12 +2181,13 @@ function M.move_down()
     -- Bottom prompt with reverse rendering: visually moving DOWN means cursor DECREASES
     -- because lower index items (better) are rendered at higher line numbers
     if M.state.cursor <= M.state.pagination.prefetch_margin + 1 and M.state.cursor <= 1 then
-      -- Wrap around takes priority: at first item, jump to last
-      if wrap_around then
-        M.state.cursor = items_count
-      elseif M.state.pagination.page_index > 0 then
+      if M.state.pagination.page_index > 0 then
+        -- More pages available: paginate normally
         vim.schedule(M.load_previous_page)
         return
+      elseif wrap_around then
+        -- At global start (first item on first page): wrap to last
+        M.wrap_to_last()
       end
     else
       M.state.cursor = math.max(M.state.cursor - 1, 1)
@@ -2143,24 +2198,24 @@ function M.move_down()
     local at_last_item = M.state.cursor >= items_count
 
     if near_bottom and at_last_item then
-      -- Wrap around takes priority: at last item, jump to first
-      if wrap_around then
-        M.state.cursor = 1
-      else
-        local page_size = M.state.pagination.page_size
-        if page_size > 0 then
-          local has_more
-          if M.state.mode == 'grep' then
-            has_more = M.state.pagination.grep_next_file_offset > 0
-          else
-            local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
-            has_more = M.state.pagination.page_index < max_page
-          end
-          if has_more then
-            M.load_next_page()
-            return
-          end
+      local page_size = M.state.pagination.page_size
+      local has_more = false
+      if page_size > 0 then
+        if M.state.mode == 'grep' then
+          has_more = M.state.pagination.grep_next_file_offset > 0
+        else
+          local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
+          has_more = M.state.pagination.page_index < max_page
         end
+      end
+
+      if has_more then
+        -- More pages available: paginate normally
+        M.load_next_page()
+        return
+      elseif wrap_around then
+        -- At global end (last item on last page): wrap to first
+        M.wrap_to_first()
       end
     else
       M.state.cursor = math.min(M.state.cursor + 1, items_count)

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -895,8 +895,18 @@ local function move_list_cursor(direction)
   local items = M.state.filtered_items
   if #items == 0 then return end
 
+  local wrap_around = M.state.config and M.state.config.wrap_around or false
   local new_cursor = M.state.cursor + direction
-  new_cursor = math.max(1, math.min(new_cursor, #items))
+
+  if wrap_around then
+    if new_cursor < 1 then
+      new_cursor = #items
+    elseif new_cursor > #items then
+      new_cursor = 1
+    end
+  else
+    new_cursor = math.max(1, math.min(new_cursor, #items))
+  end
 
   if new_cursor ~= M.state.cursor then
     M.state.cursor = new_cursor
@@ -2036,6 +2046,7 @@ function M.move_up()
 
   local prompt_position = get_prompt_position()
   local items_count = #M.state.filtered_items
+  local wrap_around = M.state.config and M.state.config.wrap_around or false
 
   -- Pagination logic depends on prompt position
   if prompt_position == 'bottom' then
@@ -2059,9 +2070,14 @@ function M.move_up()
           return
         end
       end
-    end
 
-    M.state.cursor = math.min(M.state.cursor + 1, items_count)
+      -- Wrap around: at last item with no more pages, jump to first
+      if wrap_around then
+        M.state.cursor = 1
+      end
+    else
+      M.state.cursor = math.min(M.state.cursor + 1, items_count)
+    end
   else
     -- Top prompt: scrolling UP means going to BETTER results (previous page)
     if M.state.cursor <= M.state.pagination.prefetch_margin + 1 and M.state.cursor <= 1 then
@@ -2069,9 +2085,14 @@ function M.move_up()
         vim.schedule(M.load_previous_page)
         return
       end
-    end
 
-    M.state.cursor = math.max(M.state.cursor - 1, 1)
+      -- Wrap around: at first item with no previous pages, jump to last
+      if wrap_around then
+        M.state.cursor = items_count
+      end
+    else
+      M.state.cursor = math.max(M.state.cursor - 1, 1)
+    end
   end
 
   M.render_list()
@@ -2101,6 +2122,7 @@ function M.move_down()
 
   local prompt_position = get_prompt_position()
   local items_count = #M.state.filtered_items
+  local wrap_around = M.state.config and M.state.config.wrap_around or false
 
   -- Pagination logic depends on prompt position
   if prompt_position == 'bottom' then
@@ -2111,9 +2133,14 @@ function M.move_down()
         vim.schedule(M.load_previous_page)
         return
       end
-    end
 
-    M.state.cursor = math.max(M.state.cursor - 1, 1)
+      -- Wrap around: at first item with no previous pages, jump to last
+      if wrap_around then
+        M.state.cursor = items_count
+      end
+    else
+      M.state.cursor = math.max(M.state.cursor - 1, 1)
+    end
   else
     -- Top prompt: scrolling DOWN means going to WORSE results (next page)
     local near_bottom = M.state.cursor >= (items_count - M.state.pagination.prefetch_margin)
@@ -2134,9 +2161,14 @@ function M.move_down()
           return
         end
       end
-    end
 
-    M.state.cursor = math.min(M.state.cursor + 1, items_count)
+      -- Wrap around: at last item with no more pages, jump to first
+      if wrap_around then
+        M.state.cursor = 1
+      end
+    else
+      M.state.cursor = math.min(M.state.cursor + 1, items_count)
+    end
   end
 
   M.render_list()

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2050,16 +2050,12 @@ function M.wrap_to_first()
 
   -- For non-grep mode, jump directly to page 0
   if M.state.mode ~= 'grep' then
-    return M.load_page_at_index(0, function()
-      M.state.cursor = 1
-    end)
+    return M.load_page_at_index(0, function() M.state.cursor = 1 end)
   end
 
   -- For grep mode, we can only go back if page 0 offset is recorded
   if M.state.pagination.grep_file_offsets[1] ~= nil then
-    return M.load_page_at_index(0, function()
-      M.state.cursor = 1
-    end)
+    return M.load_page_at_index(0, function() M.state.cursor = 1 end)
   end
 
   M.state.cursor = 1
@@ -2082,9 +2078,7 @@ function M.wrap_to_last()
       return true
     end
 
-    return M.load_page_at_index(max_page_index, function(result_count)
-      M.state.cursor = result_count
-    end)
+    return M.load_page_at_index(max_page_index, function(result_count) M.state.cursor = result_count end)
   end
 
   -- For grep mode, we can't jump to last page (sequential offsets required)

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2056,24 +2056,24 @@ function M.move_up()
     local at_last_item = M.state.cursor >= items_count
 
     if near_bottom and at_last_item then
-      local page_size = M.state.pagination.page_size
-      if page_size > 0 then
-        local has_more
-        if M.state.mode == 'grep' then
-          has_more = M.state.pagination.grep_next_file_offset > 0
-        else
-          local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
-          has_more = M.state.pagination.page_index < max_page
-        end
-        if has_more then
-          M.load_next_page()
-          return
-        end
-      end
-
-      -- Wrap around: at last item with no more pages, jump to first
+      -- Wrap around takes priority: at last item, jump to first
       if wrap_around then
         M.state.cursor = 1
+      else
+        local page_size = M.state.pagination.page_size
+        if page_size > 0 then
+          local has_more
+          if M.state.mode == 'grep' then
+            has_more = M.state.pagination.grep_next_file_offset > 0
+          else
+            local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
+            has_more = M.state.pagination.page_index < max_page
+          end
+          if has_more then
+            M.load_next_page()
+            return
+          end
+        end
       end
     else
       M.state.cursor = math.min(M.state.cursor + 1, items_count)
@@ -2081,14 +2081,12 @@ function M.move_up()
   else
     -- Top prompt: scrolling UP means going to BETTER results (previous page)
     if M.state.cursor <= M.state.pagination.prefetch_margin + 1 and M.state.cursor <= 1 then
-      if M.state.pagination.page_index > 0 then
-        vim.schedule(M.load_previous_page)
-        return
-      end
-
-      -- Wrap around: at first item with no previous pages, jump to last
+      -- Wrap around takes priority: at first item, jump to last
       if wrap_around then
         M.state.cursor = items_count
+      elseif M.state.pagination.page_index > 0 then
+        vim.schedule(M.load_previous_page)
+        return
       end
     else
       M.state.cursor = math.max(M.state.cursor - 1, 1)
@@ -2129,14 +2127,12 @@ function M.move_down()
     -- Bottom prompt with reverse rendering: visually moving DOWN means cursor DECREASES
     -- because lower index items (better) are rendered at higher line numbers
     if M.state.cursor <= M.state.pagination.prefetch_margin + 1 and M.state.cursor <= 1 then
-      if M.state.pagination.page_index > 0 then
-        vim.schedule(M.load_previous_page)
-        return
-      end
-
-      -- Wrap around: at first item with no previous pages, jump to last
+      -- Wrap around takes priority: at first item, jump to last
       if wrap_around then
         M.state.cursor = items_count
+      elseif M.state.pagination.page_index > 0 then
+        vim.schedule(M.load_previous_page)
+        return
       end
     else
       M.state.cursor = math.max(M.state.cursor - 1, 1)
@@ -2147,24 +2143,24 @@ function M.move_down()
     local at_last_item = M.state.cursor >= items_count
 
     if near_bottom and at_last_item then
-      local page_size = M.state.pagination.page_size
-      if page_size > 0 then
-        local has_more
-        if M.state.mode == 'grep' then
-          has_more = M.state.pagination.grep_next_file_offset > 0
-        else
-          local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
-          has_more = M.state.pagination.page_index < max_page
-        end
-        if has_more then
-          M.load_next_page()
-          return
-        end
-      end
-
-      -- Wrap around: at last item with no more pages, jump to first
+      -- Wrap around takes priority: at last item, jump to first
       if wrap_around then
         M.state.cursor = 1
+      else
+        local page_size = M.state.pagination.page_size
+        if page_size > 0 then
+          local has_more
+          if M.state.mode == 'grep' then
+            has_more = M.state.pagination.grep_next_file_offset > 0
+          else
+            local max_page = math.max(0, math.ceil(M.state.pagination.total_matched / page_size) - 1)
+            has_more = M.state.pagination.page_index < max_page
+          end
+          if has_more then
+            M.load_next_page()
+            return
+          end
+        end
       end
     else
       M.state.cursor = math.min(M.state.cursor + 1, items_count)


### PR DESCRIPTION
## Summary

When enabled (`wrap_around = true`), the cursor wraps to the opposite end when reaching the first or last item in the results list, instead of stopping at the boundary.

This is a common UX pattern in fuzzy finders like Telescope and fzf, where pressing up at the top item jumps to the bottom, and pressing down at the bottom item jumps to the top.

## Changes

- Added `wrap_around` config option (defaults to `false` to preserve existing behavior)
- Updated `move_up`, `move_down`, and `move_list_cursor` in `picker_ui.lua` to support wrapping
- Works with both `top` and `bottom` prompt positions
- Pagination still takes priority: wrapping only occurs when there are no more pages to load

## Usage

```lua
vim.g.fff = {
  wrap_around = true,
}
```

## Type annotations

Added `wrap_around` field to `FffKeymapsConfig` and `FffConfig` type annotations.