### PR TITLE
fix(pi-fff): avoid editor overwrite when tools-only mode is enabled

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -496,8 +496,8 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     try {
       activeCwd = ctx.cwd;
+      if (shouldEnableMentions()) applyEditorMode(ctx);
       await ensureFinder(activeCwd);
-      applyEditorMode(ctx);
     } catch (e: unknown) {
       ctx.ui.notify(
         `FFF init failed: ${e instanceof Error ? e.message : String(e)}`,


### PR DESCRIPTION
## Summary
- `pi-fff` currently overwrites editor/statusline components installed by other extensions after startup even when `tools-only` mode is enabled
- this skips editor changes on startup when mentions are disabled (`tools-only`)