### PR TITLE
fix: Segementation fault updating frecency

### DIFF
--- a/crates/fff-core/src/background_watcher.rs
+++ b/crates/fff-core/src/background_watcher.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::file_picker::{FFFMode, FilePicker};
+use crate::file_picker::{FFFMode, MAX_OVERFLOW_FILES};
 use crate::git::GitStatusCache;
 use crate::shared::{SharedFilePicker, SharedFrecency};
 use crate::sort_buffer::sort_with_buffer;
@@ -33,7 +33,6 @@ const MAX_MACOS_NONRECURSIVE_WATCHES: usize = 4096;
 /// Minimum seconds between frecency tracks of the same file in AI mode.
 /// Prevents score inflation from rapid burst edits by AI agents.
 const AI_MODE_COOLDOWN_SECS: u64 = 5 * 60;
-const MAX_OVERFLOW_FILES: usize = 1024;
 
 impl BackgroundWatcher {
     pub fn new(
@@ -468,12 +467,11 @@ fn handle_debounced_events(
             //   - Remove events are not always emitted (macOS often sends
             //     Modify(Name(Any)) instead of Remove).
             let is_removal = matches!(debounced_event.event.kind, EventKind::Remove(_));
-            // Directory-level remove: macOS FSEvents delivers a single
+
+            // Directory-level remove: both fsevents and inotify delivers a single
             // `Remove(Folder)` event for a whole directory tree (e.g.
             // after `git reset --hard` wipes a dir full of staged-but-
-            // uncommitted files). Individual per-file Remove events for
-            // the children do *not* arrive. Treat the folder removal as
-            // "evict every indexed descendant".
+            // uncommitted files).
             let is_folder_removal = matches!(
                 debounced_event.event.kind,
                 EventKind::Remove(notify::event::RemoveKind::Folder)
@@ -536,9 +534,20 @@ fn handle_debounced_events(
         new_dirs_to_watch.len()
     );
 
-    // Apply file index updates (add/remove) unconditionally — these must
-    // happen even when there is no git repository.
-    let (files_to_update_git_status, overflow_count) = if !paths_to_remove.is_empty()
+    if paths_to_remove.is_empty()
+        && dirs_to_remove.is_empty()
+        && paths_to_add_or_modify.is_empty()
+        && !need_full_git_rescan
+    {
+        debug!("No file index changes to apply");
+        return new_dirs_to_watch;
+    }
+
+    let mut files_to_update_git_status = Vec::new();
+    let mut need_full_rescan = false;
+    let mut overflow_count = 0;
+
+    if !paths_to_remove.is_empty()
         || !dirs_to_remove.is_empty()
         || !paths_to_add_or_modify.is_empty()
     {
@@ -549,39 +558,6 @@ fn handle_debounced_events(
             paths_to_add_or_modify.len(),
         );
 
-        let apply_changes = |picker: &mut FilePicker| -> (Vec<PathBuf>, usize) {
-            // Remove whole directories first so any subsequent single-file
-            // remove event for a path that lived under them becomes a cheap
-            // no-op rather than a failed lookup.
-            for dir in &dirs_to_remove {
-                let count = picker.remove_all_files_in_dir(dir);
-                debug!("remove_all_files_in_dir({:?}) -> {} files", dir, count);
-            }
-
-            for path in &paths_to_remove {
-                let removed = picker.remove_file_by_path(path);
-                debug!("remove_file_by_path({:?}) -> {}", path, removed);
-            }
-
-            let mut files_to_update = Vec::with_capacity(paths_to_add_or_modify.len());
-            for path in &paths_to_add_or_modify {
-                let added = picker.on_create_or_modify(path).is_some();
-                if added {
-                    debug!("on_create_or_modify({:?}) -> Some", path);
-                    files_to_update.push(path.to_path_buf());
-                } else {
-                    error!("on_create_or_modify({:?}) -> None (file not added!)", path);
-                }
-            }
-            let overflow_count = picker.get_overflow_files().len();
-            info!(
-                "apply_changes complete: {} files to update git status, overflow={}",
-                files_to_update.len(),
-                overflow_count,
-            );
-            (files_to_update, overflow_count)
-        };
-
         let Ok(mut guard) = shared_picker.write() else {
             error!("Failed to acquire file picker write lock");
             return new_dirs_to_watch;
@@ -590,27 +566,38 @@ fn handle_debounced_events(
             error!("File picker not initialized");
             return new_dirs_to_watch;
         };
-        apply_changes(picker)
-    } else {
-        debug!("No file index changes to apply");
-        (Vec::new(), 0)
-    };
 
-    // The overflow arena grows monotonically as new files are created — a
-    // file's chunks are added on creation but never reclaimed on removal.
-    // On directories with high churn (e.g. `$HOME` with editor temp files,
-    // browser caches) this inflates RSS unboundedly. Once overflow exceeds
-    // the threshold, fall back to a full rescan: that replaces `sync_data`
-    // and drops the builder arena, which is the only path that reclaims it.
-    if overflow_count > MAX_OVERFLOW_FILES {
-        warn!(
-            ?overflow_count,
-            "Overflow count exceeded the threshold, triggering full rescan.",
+        for dir in &dirs_to_remove {
+            let count = picker.remove_all_files_in_dir(dir);
+            debug!("remove_all_files_in_dir({:?}) -> {} files", dir, count);
+        }
+
+        for path in &paths_to_remove {
+            let removed = picker.remove_file_by_path(path);
+            debug!("remove_file_by_path({:?}) -> {}", path, removed);
+        }
+
+        files_to_update_git_status.reserve(paths_to_add_or_modify.len());
+        for path in &paths_to_add_or_modify {
+            if picker.handle_create_or_modify(path).is_some() {
+                files_to_update_git_status.push(path.to_path_buf());
+            } else {
+                need_full_rescan = true;
+            }
+        }
+
+        overflow_count = picker.get_overflow_files().len();
+        info!(
+            files_updated = files_to_update_git_status.len(),
+            overflow_count, "File index changes applied",
         );
+    }
+
+    if need_full_rescan || overflow_count > MAX_OVERFLOW_FILES {
+        info!("Watcher faced limit of index overflow. Triggering rescan");
         if let Err(e) = shared_picker.trigger_full_rescan_async(shared_frecency) {
             error!("Failed to trigger full rescan: {:?}", e);
         }
-        return new_dirs_to_watch;
     }
 
     // AI mode: auto-track frecency for all modified/created files.
@@ -663,25 +650,16 @@ fn handle_debounced_events(
         return new_dirs_to_watch;
     };
 
-    if need_full_git_rescan {
+    if need_full_git_rescan && !need_full_rescan {
         info!("Triggering full git rescan");
 
         if let Err(e) = shared_picker.refresh_git_status(shared_frecency) {
             error!("Failed to refresh git status: {:?}", e);
         }
-        // IMPORTANT: do NOT return here. When a batch contains both
-        // `.git/index` events (e.g. from `git add`) AND worktree-file
-        // Modify events (e.g. a subsequent edit to the same file),
-        // `refresh_git_status` might run while libgit2 sees an
-        // intermediate state — lock-wait mitigates this but can't fully
-        // eliminate it, and refresh doesn't always observe the final
-        // worktree contents if the edit event landed just before the
-        // batch flushed. Re-running the per-path query for explicitly
-        // changed files overrides any stale bits from refresh with an
-        // authoritative per-file status read.
     }
 
-    if !files_to_update_git_status.is_empty() {
+    // do not update the git status if the
+    if !files_to_update_git_status.is_empty() && !need_full_git_rescan {
         info!(
             "Fetching git status for {} files",
             files_to_update_git_status.len()
@@ -739,7 +717,6 @@ fn track_files_from_new_directories(
         return;
     }
 
-    // brief read lock
     {
         let Ok(mut guard) = shared_picker.write() else {
             return;
@@ -750,7 +727,7 @@ fn track_files_from_new_directories(
         };
 
         for path in &files_to_add {
-            picker.on_create_or_modify(path);
+            picker.handle_create_or_modify(path);
         }
     }
 

--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -43,6 +43,7 @@ use crate::scan::{ScanConfig, ScanJob, ScanSignals};
 use crate::score::fuzzy_match_and_score_files;
 use crate::shared::{SharedFilePicker, SharedFrecency};
 use crate::simd_path::{ArenaPtr, PATH_BUF_SIZE};
+use crate::stable_vec::StableVec;
 use crate::types::{
     ContentCacheBudget, DirItem, DirSearchResult, FileItem, MixedItemRef, MixedSearchResult,
     PaginationArgs, Score, ScoringContext, SearchResult,
@@ -60,6 +61,11 @@ use std::sync::{
 use std::thread::JoinHandle;
 use std::time::SystemTime;
 use tracing::{Level, debug, error, info, warn};
+
+/// Max overflow files before the watcher triggers a full rescan.
+/// `walk_filesystem` reserves this much extra capacity so the Vec never
+/// reallocates while raw pointers are held during post-scan.
+pub(crate) const MAX_OVERFLOW_FILES: usize = 1024;
 
 /// Dedicated thread pool for background work (scan, warmup, bigram build).
 /// Uses fewer threads than the global rayon pool so Neovim's event loop
@@ -128,7 +134,7 @@ pub(crate) struct FileSync {
     ///   `files[..indexable_count]` - indexable
     ///   `files[indexable_count..base_count]` - original-unindexable
     ///   `files[base_count..]`— overflow (created on demand)
-    files: Vec<FileItem>,
+    files: StableVec<FileItem>,
     indexable_count: usize,
     base_count: usize,
     /// Sorted directory table. Each entry is a unique parent directory of at
@@ -152,7 +158,7 @@ pub(crate) struct FileSync {
 impl FileSync {
     fn new() -> Self {
         Self {
-            files: Vec::new(),
+            files: StableVec::from_vec_with_reserve(Vec::new(), MAX_OVERFLOW_FILES),
             indexable_count: 0,
             base_count: 0,
             dirs: Vec::new(),
@@ -1230,33 +1236,60 @@ impl FilePicker {
         self.sync_data.bigram_overlay = Some(Arc::new(parking_lot::RwLock::new(overlay)));
     }
 
-    pub(crate) fn cache_budget_arc(&self) -> Arc<ContentCacheBudget> {
-        Arc::clone(&self.cache_budget)
-    }
-
-    /// Bundle the atomic flags the scan orchestrator needs. One method
-    /// instead of four separate getters so every callsite passes a
-    /// single `ScanSignals` value.
     pub(crate) fn scan_signals(&self) -> crate::scan::ScanSignals {
-        crate::scan::ScanSignals {
-            scanning: Arc::clone(&self.signals.scanning),
-            watcher_ready: Arc::clone(&self.signals.watcher_ready),
-            cancelled: Arc::clone(&self.signals.cancelled),
-            post_scan_busy: Arc::clone(&self.signals.post_scan_busy),
-            rescan_pending: Arc::clone(&self.signals.rescan_pending),
-        }
+        self.signals.clone()
     }
 
     pub(crate) fn scanned_files_counter(&self) -> Arc<AtomicUsize> {
         Arc::clone(&self.scanned_files_count)
     }
 
-    pub(crate) fn sync_data_snapshot(&self) -> (&[FileItem], usize, ArenaPtr) {
-        (
-            self.sync_data.files(),
-            self.sync_data.indexable_count,
-            self.sync_data.arena_base_ptr(),
-        )
+    /// Capture raw pointers to the picker's internal arrays for off-lock use.
+    ///
+    /// Sets `post_scan_indexing_active` and returns a snapshot that clears it
+    /// on drop. This is the ONLY approved way to escape the lock for
+    /// long-running parallel work (git status, warmup, bigram).
+    ///
+    /// Returns `None` if `post_scan_indexing_active` is already set — this
+    /// means another post-scan is in flight and we must not create a second
+    /// set of dangling pointers.
+    ///
+    /// # Safety
+    /// 1. `walk_filesystem` reserved `MAX_OVERFLOW_FILES` capacity on the
+    ///    files Vec at creation — watcher pushes cannot reallocate it.
+    /// 2. `post_scan_indexing_active` is set — prevents `commit_new_sync`
+    ///    from replacing the Vec (ScanJob::new checks this flag).
+    /// 3. Only `[..base_count]` is accessed — base files use the immutable
+    ///    base arena. Overflow files use a different arena.
+    pub(crate) unsafe fn post_scan_snapshot(&self) -> Option<PostScanUnsafeSnapshot> {
+        if self
+            .signals
+            .post_scan_indexing_active
+            .load(Ordering::Acquire)
+        {
+            tracing::error!(
+                "Can not acquire post scan unsafe snapshot, someone already acquired it"
+            );
+            return None;
+        }
+
+        self.signals
+            .post_scan_indexing_active
+            .store(true, Ordering::Release);
+
+        let files = &self.sync_data.files;
+        let dirs = &self.sync_data.dirs;
+        Some(PostScanUnsafeSnapshot {
+            files: files.as_ptr() as *mut FileItem,
+            base_count: self.sync_data.base_count,
+            indexable_count: self.sync_data.indexable_count,
+            dirs: dirs.as_ptr(),
+            dirs_len: dirs.len(),
+            arena: self.sync_data.arena_base_ptr(),
+            budget: &*self.cache_budget as *const _,
+            base_path: self.base_path.clone(),
+            post_scan_flag: Arc::clone(&self.signals.post_scan_indexing_active),
+        })
     }
 
     pub(crate) fn commit_new_sync(&mut self, sync: FileSync) {
@@ -1359,8 +1392,11 @@ impl FilePicker {
         index.and_then(|i| self.sync_data.get_file_mut(i))
     }
 
+    /// Handle the event of certain file being modified or adds a neww file if it is not added
+    /// If this function returns `None` it means that picker is in the invalid state, or the capacity
+    /// of index is exhausted and a new rescan needs to be triggered.
     #[tracing::instrument(skip(self),level = Level::DEBUG)]
-    pub fn on_create_or_modify(&mut self, path: impl AsRef<Path> + Debug) -> Option<&FileItem> {
+    pub fn handle_create_or_modify(&mut self, path: impl AsRef<Path> + Debug) -> Option<&FileItem> {
         let path = path.as_ref();
 
         if let Ok(idx) = self.sync_data.find_file_index(path, &self.base_path) {
@@ -1420,7 +1456,8 @@ impl FilePicker {
         Some(&*self.sync_data.get_file_mut(pos)?)
     }
 
-    /// Adds a new file from path to the picker, even if it should be ignored
+    /// Adds a new file to picker, if the file can not be added returns `None`
+    /// which indicates that it's time to trigger a new sync
     #[tracing::instrument(skip(self))]
     pub fn add_new_file(&mut self, path: &Path) -> Option<&FileItem> {
         // On Windows `pathdiff::diff_paths` is byte-wise, so a short-name
@@ -1456,7 +1493,10 @@ impl FilePicker {
         file_item.set_path(chunked_path);
         file_item.set_overflow(true);
 
-        self.sync_data.files.push(file_item);
+        if !self.sync_data.files.push(file_item) {
+            return None;
+        }
+
         self.sync_data.files.last()
     }
 
@@ -1600,6 +1640,36 @@ impl FileSlot {
         }
     }
 }
+
+/// Raw pointers captured from the picker for off-lock parallel work.
+/// Created by [`FilePicker::post_scan_snapshot`]. See its safety docs.
+///
+/// Clears `post_scan_indexing_active` on drop — the flag is set by
+/// `post_scan_snapshot` and MUST only be cleared by dropping this struct.
+pub(crate) struct PostScanUnsafeSnapshot {
+    pub files: *mut FileItem,
+    pub base_count: usize,
+    pub indexable_count: usize,
+    pub dirs: *const crate::types::DirItem,
+    pub dirs_len: usize,
+    pub arena: ArenaPtr,
+    pub budget: *const crate::types::ContentCacheBudget,
+    pub base_path: PathBuf,
+    /// Holds the flag reference so it is automatically flips
+    /// when the pointsr
+    post_scan_flag: Arc<AtomicBool>,
+}
+
+impl Drop for PostScanUnsafeSnapshot {
+    fn drop(&mut self) {
+        self.post_scan_flag.store(false, Ordering::Release);
+    }
+}
+
+// SAFETY: the pointers are derived from Vec/Arc storage that outlives
+// any use of this struct (guaranteed by reserve + post_scan_indexing_active).
+unsafe impl Send for PostScanUnsafeSnapshot {}
+unsafe impl Sync for PostScanUnsafeSnapshot {}
 
 /// A point-in-time snapshot of the file-scanning progress.
 ///
@@ -1883,7 +1953,7 @@ impl FileSync {
         let base_count = files.len();
 
         Ok(FileSync {
-            files,
+            files: StableVec::from_vec_with_reserve(files, MAX_OVERFLOW_FILES),
             indexable_count,
             base_count,
             dirs,
@@ -1940,105 +2010,6 @@ fn populates_dirs_files_chunked_storage<'a>(
     }
 
     dirs
-}
-
-pub(crate) fn apply_git_status_and_frecency(
-    shared_picker: &SharedFilePicker,
-    shared_frecency: &SharedFrecency,
-    git_handle: std::thread::JoinHandle<Option<GitStatusCache>>,
-    mode: FFFMode,
-) {
-    let join_start = std::time::Instant::now();
-    let git_cache = match git_handle.join() {
-        Ok(cache) => cache,
-        Err(_) => {
-            error!("Git status thread panicked");
-            return;
-        }
-    };
-    info!("SCAN: Git status ready in {:?}", join_start.elapsed());
-
-    let Some(git_cache) = git_cache else { return };
-
-    // Take a snapshot of the raw pointers + metadata under a brief read
-    // lock, then drop the guard BEFORE running the rayon loop. Previously
-    // we held the picker write lock for the whole loop (multi-second:
-    // 500k files × LMDB read per file), which froze every FFI caller on
-    // the main nvim thread — searches, progress polls, BufEnter tracking.
-    //
-    // SAFETY: the scan thread is the only writer that replaces
-    // `sync_data` during post-scan. `post_scan_busy` blocks rescans; git
-    // status is applied exactly once per scan, on this thread, before
-    // anything else races for the files slice. The overflow watcher only
-    // appends to `files[base_count..]` — we only mutate `files[..]` here,
-    // and we deliberately do not touch or dereference the overflow tail.
-    #[allow(clippy::type_complexity)]
-    let snapshot: Option<(
-        *mut FileItem,
-        usize,
-        *const crate::types::DirItem,
-        usize,
-        PathBuf,
-        ArenaPtr,
-    )> = shared_picker.read().ok().and_then(|guard| {
-        guard.as_ref().map(|picker| {
-            let files = &picker.sync_data.files;
-            let dirs = &picker.sync_data.dirs;
-            (
-                files.as_ptr() as *mut FileItem,
-                files.len(),
-                dirs.as_ptr(),
-                dirs.len(),
-                picker.base_path.clone(),
-                picker.arena_base_ptr(),
-            )
-        })
-    });
-
-    let Some((files_ptr, files_len, dirs_ptr, dirs_len, bp, arena)) = snapshot else {
-        return;
-    };
-
-    let frecency = shared_frecency.read().ok();
-    let frecency_ref = frecency.as_ref().and_then(|f| f.as_ref());
-
-    // SAFETY: the scan thread is the sole replacer of `sync_data`; it
-    // won't run again until this function returns. See module-level
-    // comments on the post-scan phase for the full ordering argument.
-    let files: &mut [FileItem] = unsafe { std::slice::from_raw_parts_mut(files_ptr, files_len) };
-    let dirs: &[crate::types::DirItem] = unsafe { std::slice::from_raw_parts(dirs_ptr, dirs_len) };
-
-    // Reset dir frecency before recomputation.
-    for dir in dirs.iter() {
-        dir.reset_frecency();
-    }
-
-    BACKGROUND_THREAD_POOL.install(|| {
-        files.par_iter_mut().for_each(|file| {
-            let mut buf = [0u8; crate::simd_path::PATH_BUF_SIZE];
-            let absolute_path = file.write_absolute_path(arena, &bp, &mut buf);
-
-            file.git_status = git_cache.lookup_status(absolute_path);
-            if let Some(frecency) = frecency_ref {
-                let _ = file.update_frecency_scores(frecency, arena, &bp, mode);
-            }
-
-            let score = file.access_frecency_score as i32;
-            if score > 0 {
-                let dir_idx = file.parent_dir_index() as usize;
-                if let Some(dir) = dirs.get(dir_idx) {
-                    dir.update_frecency_if_larger(score);
-                }
-            }
-        });
-    });
-    drop(frecency);
-
-    info!(
-        "SCAN: Applied git status to {} files ({} dirty)",
-        files_len,
-        git_cache.statuses_len(),
-    );
 }
 
 /// Fast extension-based binary detection. Avoids opening files during scan.

--- a/crates/fff-core/src/grep.rs
+++ b/crates/fff-core/src/grep.rs
@@ -2564,7 +2564,7 @@ mod tests {
             let mut f = std::fs::File::create(&path).unwrap();
             writeln!(f, "overflow unicorn entry").unwrap();
             drop(f);
-            picker.on_create_or_modify(&path);
+            picker.handle_create_or_modify(&path);
         }
         assert_eq!(picker.get_files().len(), 8);
 

--- a/crates/fff-core/src/lib.rs
+++ b/crates/fff-core/src/lib.rs
@@ -102,6 +102,7 @@ mod constraints;
 mod error;
 mod score;
 mod sort_buffer;
+pub(crate) mod stable_vec;
 // this is pub only for benchmarks
 pub mod case_insensitive_memmem;
 

--- a/crates/fff-core/src/scan.rs
+++ b/crates/fff-core/src/scan.rs
@@ -33,13 +33,12 @@ use crate::background_watcher::BackgroundWatcher;
 use crate::bigram_filter::BigramOverlay;
 use crate::bigram_filter::build_bigram_index;
 use crate::error::Error;
-use crate::file_picker::{self, FFFMode, warmup_mmaps};
+use crate::file_picker::{BACKGROUND_THREAD_POOL, FFFMode, warmup_mmaps};
+use crate::git::GitStatusCache;
 use crate::shared::{SharedFilePicker, SharedFrecency};
 use crate::types::ContentCacheBudget;
+use rayon::prelude::*;
 
-/// Shared atomic flags surfaced by the picker for the scan worker to
-/// signal its progress. Grouped so every callsite passes one value,
-/// not four.
 #[derive(Clone, Default)]
 pub(crate) struct ScanSignals {
     /// Set to `true` while any scan phase is running
@@ -48,10 +47,12 @@ pub(crate) struct ScanSignals {
     pub(crate) watcher_ready: Arc<AtomicBool>,
     /// Indicates that that owning picker was requested to shut down
     pub(crate) cancelled: Arc<AtomicBool>,
-    /// Soft lock indicating that the post scan non blocking work is active
-    pub(crate) post_scan_busy: Arc<AtomicBool>,
     /// Used to resolve conflicts if multiple rescans were triggered in a queue
     pub(crate) rescan_pending: Arc<AtomicBool>,
+    /// Set by `post_scan_snapshot`, cleared by `PostScanSnapshot::drop`.
+    /// DO NOT set or clear this manually — it is managed exclusively by the
+    /// PostScanSnapshot lifecycle.
+    pub(crate) post_scan_indexing_active: Arc<AtomicBool>,
 }
 
 /// Which optional phases a scan should run.
@@ -83,44 +84,48 @@ pub(crate) struct ScanJob {
 }
 
 impl ScanJob {
-    pub fn new(
+    pub fn new_rescan(
         shared_picker: &SharedFilePicker,
         shared_frecency: &SharedFrecency,
-        install_watcher: bool,
     ) -> Result<Option<Self>, Error> {
         let guard = shared_picker.read()?;
         let picker = guard.as_ref().ok_or(Error::FilePickerMissing)?;
 
-        if picker.is_scan_active() {
+        if picker.is_scan_active()
+            || picker
+                .signals
+                .post_scan_indexing_active
+                .load(Ordering::Acquire)
+        {
             return Ok(None);
         }
 
+        let mode = picker.mode();
         let signals = picker.scan_signals();
-        if signals.post_scan_busy.load(Ordering::Acquire) {
-            return Ok(None);
-        }
+        let scanned_files_counter = picker.scanned_files_counter();
+        let base_path = picker.base_path().to_path_buf();
+
+        let new_scan_config = ScanConfig {
+            warmup: picker.has_mmap_cache(),
+            content_indexing: picker.has_content_indexing(),
+            watch: picker.has_watcher(),
+            auto_cache_budget: !picker.has_explicit_cache_budget(),
+            install_watcher: false, // the watcher is independent of rescan, it is not restarting EVER
+        };
+
+        drop(guard); // just a sanity check
 
         Ok(Some(Self {
+            mode,
+            signals,
+            base_path,
+            scanned_files_counter,
+            config: new_scan_config,
             shared_picker: shared_picker.clone(),
             shared_frecency: shared_frecency.clone(),
-            base_path: picker.base_path().to_path_buf(),
-            mode: picker.mode(),
-            signals,
-            scanned_files_counter: picker.scanned_files_counter(),
-            config: ScanConfig {
-                warmup: picker.has_mmap_cache(),
-                content_indexing: picker.has_content_indexing(),
-                watch: picker.has_watcher(),
-                auto_cache_budget: !picker.has_explicit_cache_budget(),
-                install_watcher,
-            },
         }))
     }
 
-    /// Same as [`new`] but without reading from the picker — caller
-    /// supplies the base path / mode / flags directly. Used by the
-    /// bootstrap scan before the `FilePicker` is published to
-    /// `SharedPicker`.
     pub fn new_initial(
         shared_picker: SharedFilePicker,
         shared_frecency: SharedFrecency,
@@ -209,19 +214,14 @@ impl ScanJob {
         // in case we do a rescan, we have to resubscribe a watcher to the new set of directories
         // all the already watched directories are not going to be resubscribed
         if !config.install_watcher && !signals.cancelled.load(Ordering::Acquire) {
-            resubscribe_to_new_picker(&shared_picker);
+            rescubscribe_watcher_post_scan(&shared_picker);
         }
 
         // 3. Apply git status + frecency off-lock.
         if !signals.cancelled.load(Ordering::Acquire)
             && let Some(status_handle) = status_handle
         {
-            file_picker::apply_git_status_and_frecency(
-                &shared_picker,
-                &shared_frecency,
-                status_handle,
-                mode,
-            );
+            apply_git_status_and_frecency(&shared_picker, &shared_frecency, status_handle, mode);
         }
 
         // 4. Install filesystem watcher (initial scan only).
@@ -251,7 +251,7 @@ impl ScanJob {
         // 5. Post-scan warmup + bigram build.
         if (config.warmup || config.content_indexing) && !signals.cancelled.load(Ordering::Acquire)
         {
-            run_post_scan(&shared_picker, &base_path, &signals, &config);
+            Self::run_post_scan(&shared_picker, &signals, &config);
         }
 
         // 6. Drain any rescan that arrived while we were busy.
@@ -265,7 +265,7 @@ impl ScanJob {
         if !signals.cancelled.load(Ordering::Acquire)
             && signals.rescan_pending.swap(false, Ordering::AcqRel)
         {
-            match Self::new(&shared_picker, &shared_frecency, false) {
+            match Self::new_rescan(&shared_picker, &shared_frecency) {
                 Ok(Some(follow_up)) => {
                     info!("Rescheduling deferred rescan after current scan finished");
                     follow_up.spawn();
@@ -280,6 +280,87 @@ impl ScanJob {
                 Err(e) => {
                     error!(?e, "Failed to reschedule deferred rescan");
                 }
+            }
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn run_post_scan(shared_picker: &SharedFilePicker, signals: &ScanSignals, config: &ScanConfig) {
+        // Auto-scale the cache budget before we take the files snapshot
+        if config.auto_cache_budget
+            && !signals.cancelled.load(Ordering::Acquire)
+            && let Ok(mut guard) = shared_picker.write()
+            && let Some(picker) = guard.as_mut()
+            && !picker.has_explicit_cache_budget()
+        {
+            let file_count = picker.get_files().len();
+            picker.set_cache_budget(ContentCacheBudget::new_for_repo(file_count));
+        }
+
+        // we do unsafe dirty capturing here because we GUARANTEE that the files vec is not moving anywhere
+        let Some(unsafe_snapshot) = shared_picker.read().ok().and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(|picker| unsafe { picker.post_scan_snapshot() })
+        }) else {
+            tracing::error!("Failed to commit post scan reindexing job");
+            return;
+        };
+
+        let files: &[crate::types::FileItem] = unsafe {
+            std::slice::from_raw_parts(unsafe_snapshot.files, unsafe_snapshot.base_count)
+        };
+        let budget: &ContentCacheBudget = unsafe { &*unsafe_snapshot.budget };
+
+        if config.warmup && !signals.cancelled.load(Ordering::Acquire) {
+            warmup_mmaps(
+                files,
+                budget,
+                &unsafe_snapshot.base_path,
+                unsafe_snapshot.arena,
+            );
+        }
+
+        if config.content_indexing && !signals.cancelled.load(Ordering::Acquire) {
+            let indexable_files = &files[..unsafe_snapshot.indexable_count.min(files.len())];
+            let (index, content_binary) = build_bigram_index(
+                indexable_files,
+                budget,
+                &unsafe_snapshot.base_path,
+                unsafe_snapshot.arena,
+            );
+
+            if let Ok(mut guard) = shared_picker.write()
+                && let Some(picker) = guard.as_mut()
+            {
+                for &idx in &content_binary {
+                    if let Some(file) = picker.get_file_mut(idx) {
+                        file.set_binary(true);
+                    }
+                }
+                picker.set_bigram_index(index, BigramOverlay::new(unsafe_snapshot.indexable_count));
+            }
+        }
+
+        if config.content_indexing && !signals.cancelled.load(Ordering::Acquire) {
+            let indexable_files = &files[..unsafe_snapshot.indexable_count.min(files.len())];
+            let (index, content_binary) = build_bigram_index(
+                indexable_files,
+                budget,
+                &unsafe_snapshot.base_path,
+                unsafe_snapshot.arena,
+            );
+
+            if let Ok(mut guard) = shared_picker.write()
+                && let Some(picker) = guard.as_mut()
+            {
+                for &idx in &content_binary {
+                    if let Some(file) = picker.get_file_mut(idx) {
+                        file.set_binary(true);
+                    }
+                }
+
+                picker.set_bigram_index(index, BigramOverlay::new(unsafe_snapshot.indexable_count));
             }
         }
     }
@@ -312,80 +393,11 @@ impl Drop for ScanningGuard<'_> {
     }
 }
 
-fn run_post_scan(
-    shared_picker: &SharedFilePicker,
-    base_path: &std::path::Path,
-    signals: &ScanSignals,
-    config: &ScanConfig,
-) {
-    let phase_start = std::time::Instant::now();
-
-    // Auto-scale the cache budget before we take the files snapshot —
-    // warmup needs the final budget.
-    if config.auto_cache_budget
-        && !signals.cancelled.load(Ordering::Acquire)
-        && let Ok(mut guard) = shared_picker.write()
-        && let Some(picker) = guard.as_mut()
-        && !picker.has_explicit_cache_budget()
-    {
-        let (files, _, _) = picker.sync_data_snapshot();
-        picker.set_cache_budget(ContentCacheBudget::new_for_repo(files.len()));
-    }
-
-    let Some((files, indexable_count, budget, arena, _busy_guard)) = shared_picker
-        .read()
-        .ok()
-        .and_then(|guard| guard.as_ref().map(|p| snapshot_sync_data(p, signals)))
-    else {
-        return;
-    };
-
-    if config.warmup && !signals.cancelled.load(Ordering::Acquire) {
-        let t = std::time::Instant::now();
-        warmup_mmaps(files, &budget, base_path, arena);
-        info!(
-            "Warmup completed in {:.2}s (cached {} files, {} bytes)",
-            t.elapsed().as_secs_f64(),
-            budget.cached_count.load(Ordering::Relaxed),
-            budget.cached_bytes.load(Ordering::Relaxed),
-        );
-    }
-
-    if config.content_indexing && !signals.cancelled.load(Ordering::Acquire) {
-        let indexable_files = &files[..indexable_count.min(files.len())];
-        let (index, content_binary) =
-            build_bigram_index(indexable_files, &budget, base_path, arena);
-
-        if let Ok(mut guard) = shared_picker.write()
-            && let Some(picker) = guard.as_mut()
-        {
-            for &idx in &content_binary {
-                if let Some(file) = picker.get_file_mut(idx) {
-                    file.set_binary(true);
-                }
-            }
-            picker.set_bigram_index(index, BigramOverlay::new(indexable_count));
-        }
-    }
-
-    info!(
-        "Post-scan phase total: {:.2}s (warmup={}, content_indexing={})",
-        phase_start.elapsed().as_secs_f64(),
-        config.warmup,
-        config.content_indexing,
-    );
-}
-
-struct PostScanBusyGuard<'a>(&'a AtomicBool);
-impl Drop for PostScanBusyGuard<'_> {
-    fn drop(&mut self) {
-        self.0.store(false, Ordering::Release);
-    }
-}
-
-/// Re-registers all the directories at the watcher
+/// If the scan encounters new directories created we have to add them to the watch list
+/// this is fine because the watcher does deduplicate the entries and doesn't add a lot of
+/// garbage notify watchers / fs events streams
 #[tracing::instrument(skip_all)]
-fn resubscribe_to_new_picker(shared_picker: &SharedFilePicker) {
+fn rescubscribe_watcher_post_scan(shared_picker: &SharedFilePicker) {
     let Ok(guard) = shared_picker.read() else {
         return;
     };
@@ -396,46 +408,82 @@ fn resubscribe_to_new_picker(shared_picker: &SharedFilePicker) {
         return;
     };
 
-    // Base path first — this is the watch that delivers `Create(Folder)`
-    // events for brand-new top-level subdirs. On rescan paths this
-    // watch is still alive (the BackgroundWatcher survives rescans), so
-    // the call is idempotent. Including it explicitly protects against
-    // any future refactor that could drop the initial base-path watch.
-    watcher.request_watch_dir(picker.base_path().to_path_buf());
-
     picker.for_each_dir(|dir: &std::path::Path| {
         watcher.request_watch_dir(dir.to_path_buf());
         std::ops::ControlFlow::Continue(())
     });
 }
 
-/// Take a `'static`-lifetime snapshot of `sync_data` pinned by a
-/// post-scan busy guard. Concurrent rescans short-circuit while the
-/// returned guard is alive, so the raw slice can't be freed from under
-/// the warmup + bigram build that consumes it.
-fn snapshot_sync_data<'a>(
-    picker: &crate::file_picker::FilePicker,
-    signals: &'a ScanSignals,
-) -> (
-    &'static [crate::types::FileItem],
-    usize,
-    Arc<ContentCacheBudget>,
-    crate::simd_path::ArenaPtr,
-    PostScanBusyGuard<'a>,
+fn apply_git_status_and_frecency(
+    shared_picker: &SharedFilePicker,
+    shared_frecency: &SharedFrecency,
+    git_handle: std::thread::JoinHandle<Option<GitStatusCache>>,
+    mode: FFFMode,
 ) {
-    signals.post_scan_busy.store(true, Ordering::Release);
-    let busy = PostScanBusyGuard(&signals.post_scan_busy);
+    let git_cache = match git_handle.join() {
+        Ok(Some(cache)) => cache,
+        Ok(None) => return,
+        Err(_) => {
+            error!("Git status thread panicked");
+            return;
+        }
+    };
 
-    let (files, indexable_count, arena) = picker.sync_data_snapshot();
-    let ptr = files.as_ptr();
-    let len = files.len();
-    let static_files: &'static [crate::types::FileItem] =
-        unsafe { std::slice::from_raw_parts(ptr, len) };
-    (
-        static_files,
-        indexable_count,
-        picker.cache_budget_arc(),
-        arena,
-        busy,
-    )
+    let Some(unsafe_snapshot) = shared_picker.read().ok().and_then(|guard| {
+        guard
+            .as_ref()
+            .and_then(|picker| unsafe { picker.post_scan_snapshot() })
+    }) else {
+        return;
+    };
+
+    let frecency = shared_frecency.read().ok();
+    let frecency_ref = frecency.as_ref().and_then(|f| f.as_ref());
+
+    let files: &mut [crate::types::FileItem] = unsafe {
+        std::slice::from_raw_parts_mut(unsafe_snapshot.files, unsafe_snapshot.base_count)
+    };
+    let dirs: &[crate::types::DirItem] =
+        unsafe { std::slice::from_raw_parts(unsafe_snapshot.dirs, unsafe_snapshot.dirs_len) };
+
+    // Reset dir frecency before recomputation.
+    for dir in dirs.iter() {
+        dir.reset_frecency();
+    }
+
+    BACKGROUND_THREAD_POOL.install(|| {
+        files.par_iter_mut().for_each(|file| {
+            let mut buf = [0u8; crate::simd_path::PATH_BUF_SIZE];
+            let absolute_path = file.write_absolute_path(
+                unsafe_snapshot.arena,
+                &unsafe_snapshot.base_path,
+                &mut buf,
+            );
+
+            file.git_status = git_cache.lookup_status(absolute_path);
+            if let Some(frecency) = frecency_ref {
+                let _ = file.update_frecency_scores(
+                    frecency,
+                    unsafe_snapshot.arena,
+                    &unsafe_snapshot.base_path,
+                    mode,
+                );
+            }
+
+            let score = file.access_frecency_score as i32;
+            if score > 0 {
+                let dir_idx = file.parent_dir_index() as usize;
+                if let Some(dir) = dirs.get(dir_idx) {
+                    dir.update_frecency_if_larger(score);
+                }
+            }
+        });
+    });
+    drop(frecency);
+
+    info!(
+        "SCAN: Applied git status to {} files ({} dirty)",
+        unsafe_snapshot.base_count,
+        git_cache.statuses_len(),
+    );
 }

--- a/crates/fff-core/src/shared.rs
+++ b/crates/fff-core/src/shared.rs
@@ -159,14 +159,12 @@ impl SharedFilePicker {
     /// Performs a safe async rescan. Guarantees only single active rescan per picker.
     /// If many rescans requested the last one guaranteed to be finished.
     pub fn trigger_full_rescan_async(&self, shared_frecency: &SharedFrecency) -> Result<(), Error> {
-        match ScanJob::new(self, shared_frecency, /*install_watcher=*/ false)? {
+        match ScanJob::new_rescan(self, shared_frecency)? {
             Some(job) => {
                 job.spawn();
             }
             None => {
-                // A scan is already in flight — mark a follow-up as
-                // needed. The running scan's `run()` drains this flag
-                // and reschedules itself.
+                // we can not abort the ongoing sync, but if the events
                 if let Ok(guard) = self.read()
                     && let Some(picker) = guard.as_ref()
                 {
@@ -194,25 +192,18 @@ impl SharedFilePicker {
                 return Err(Error::FilePickerMissing);
             };
 
-            debug!(
-                "Refreshing git statuses for picker: {:?}",
-                picker.git_root()
-            );
+            let git_root = picker.git_root().map(|p| p.to_path_buf());
+            drop(guard); // updating git status could take very long time, there is not risky as we
+            // do not allow any mutations and deletions of files from the sync
 
-            // Wait briefly for any in-progress git operation to release
-            // its `.git/index.lock`. libgit2 reads `.git/index` directly
-            // and does NOT coordinate with the filesystem lock; if a
-            // writer is mid-atomic-rename (lock file exists, new index
-            // not yet swapped in), we would observe stale status data.
-            // This matters most for the background watcher, which
-            // typically fires refresh in response to the very events
-            // produced by that in-flight git write.
-            if let Some(root) = picker.git_root() {
+            debug!(?git_root, "Refreshing git status for picker");
+
+            if let Some(ref root) = git_root {
                 wait_for_git_index_lock_release(root);
             }
 
             GitStatusCache::read_git_status(
-                picker.git_root(),
+                git_root.as_deref(),
                 &mut crate::git::default_status_options(),
             )
         };

--- a/crates/fff-core/src/stable_vec.rs
+++ b/crates/fff-core/src/stable_vec.rs
@@ -1,0 +1,94 @@
+/// A Vec wrapper that prevents silent reallocation.
+///
+/// The inner Vec is not exposed — all mutations go through checked
+/// methods. `push()` returns `false` when capacity is exhausted,
+/// making it structurally impossible to reallocate without an
+/// explicit new construction.
+#[derive(Clone)]
+pub(crate) struct StableVec<T>(Vec<T>);
+
+impl<T: std::fmt::Debug> std::fmt::Debug for StableVec<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("StableVec").field(&self.0.len()).finish()
+    }
+}
+
+impl<T> StableVec<T> {
+    pub fn from_vec_with_reserve(mut vec: Vec<T>, extra: usize) -> Self {
+        vec.reserve(extra);
+        Self(vec)
+    }
+
+    /// Push an item. Returns `false` if capacity is exhausted — the
+    /// item is dropped and the caller should trigger a full rescan.
+    /// In debug builds also panics to catch the logic error early.
+    #[inline]
+    pub fn push(&mut self, item: T) -> bool {
+        if self.0.len() >= self.0.capacity() {
+            debug_assert!(
+                false,
+                "StableVec: push would reallocate ({} at capacity {})",
+                self.0.len(),
+                self.0.capacity(),
+            );
+            tracing::error!(
+                len = self.0.len(),
+                capacity = self.0.capacity(),
+                "StableVec: capacity exhausted — dropping item to prevent reallocation"
+            );
+            return false;
+        }
+        self.0.push(item);
+        true
+    }
+
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> T {
+        self.0.remove(index)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.0.get_mut(index)
+    }
+
+    #[inline]
+    pub fn last(&self) -> Option<&T> {
+        self.0.last()
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.0.iter_mut()
+    }
+
+    #[inline]
+    pub fn retain<F: FnMut(&T) -> bool>(&mut self, f: F) {
+        self.0.retain(f);
+    }
+}
+
+impl<T> std::ops::Deref for StableVec<T> {
+    type Target = [T];
+    #[inline]
+    fn deref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for StableVec<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [T] {
+        &mut self.0
+    }
+}

--- a/crates/fff-core/tests/bigram_overlay_coherence_test.rs
+++ b/crates/fff-core/tests/bigram_overlay_coherence_test.rs
@@ -84,7 +84,7 @@ fn bigram_overlay_coherence_stress_base_edits_and_deletes() {
                 let mut guard = shared_picker.write().unwrap();
                 let picker = guard.as_mut().unwrap();
                 assert!(
-                    picker.on_create_or_modify(base.join(name)).is_some(),
+                    picker.handle_create_or_modify(base.join(name)).is_some(),
                     "round {round}: modify({name}) should succeed"
                 );
             }
@@ -148,7 +148,7 @@ fn bigram_overlay_coherence_long_session_incremental_edits() {
             {
                 let mut guard = shared_picker.write().unwrap();
                 let picker = guard.as_mut().unwrap();
-                picker.on_create_or_modify(base.join(name));
+                picker.handle_create_or_modify(base.join(name));
             }
             latest_tokens[file_idx] = new_token;
         }
@@ -225,7 +225,7 @@ fn bigram_overlay_coherence_resurrect_tombstoned_file() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        assert!(picker.on_create_or_modify(&target_path).is_some());
+        assert!(picker.handle_create_or_modify(&target_path).is_some());
     }
 
     {
@@ -275,7 +275,7 @@ fn bigram_overlay_coherence_proves_contribution_for_modified_base() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(&target_path);
+        picker.handle_create_or_modify(&target_path);
     }
 
     {
@@ -333,7 +333,7 @@ fn bigram_overlay_coherence_rapid_create_delete_same_base_path() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(&volatile_path);
+            picker.handle_create_or_modify(&volatile_path);
         }
 
         {
@@ -376,7 +376,7 @@ fn bigram_overlay_coherence_rapid_create_delete_same_base_path() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(&volatile_path);
+            picker.handle_create_or_modify(&volatile_path);
         }
     }
 
@@ -434,7 +434,7 @@ fn bigram_overlay_coherence_overflow_files_searchable_via_grep() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        assert!(picker.on_create_or_modify(&new_path).is_some());
+        assert!(picker.handle_create_or_modify(&new_path).is_some());
     }
 
     // Overflow file is tracked.
@@ -499,7 +499,7 @@ fn bigram_overlay_coherence_mixed_tombstones_and_overflow() {
         write_file_with_token(base, &name, &token);
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(base.join(&name));
+        picker.handle_create_or_modify(base.join(&name));
         new_tokens.push(token);
     }
 
@@ -573,7 +573,7 @@ fn bigram_overlay_coherence_full_stress_loop_with_overflow() {
             write_file_with_token(base, name, &new_token);
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(name));
+            picker.handle_create_or_modify(base.join(name));
             dead_tokens.push(old_token.clone());
             *old_token = new_token;
         }
@@ -585,7 +585,7 @@ fn bigram_overlay_coherence_full_stress_loop_with_overflow() {
             write_file_with_token(base, &name, &token);
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(&name));
+            picker.handle_create_or_modify(base.join(&name));
             live_overflow.push((name, token));
         }
 
@@ -648,7 +648,7 @@ fn bigram_overlay_coherence_overflow_file_edit_and_delete() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(&path);
+            picker.handle_create_or_modify(&path);
         }
         overflow_files.push((path, token));
     }
@@ -673,7 +673,7 @@ fn bigram_overlay_coherence_overflow_file_edit_and_delete() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(path);
+            picker.handle_create_or_modify(path);
         }
         edited_tokens.push(new_token);
     }
@@ -737,7 +737,7 @@ fn bigram_overlay_coherence_rescan_after_git_commit() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(name));
+            picker.handle_create_or_modify(base.join(name));
         }
         edited_tokens.push(token);
     }
@@ -750,7 +750,7 @@ fn bigram_overlay_coherence_rescan_after_git_commit() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(&name));
+            picker.handle_create_or_modify(base.join(&name));
         }
         new_tokens.push(token);
     }
@@ -851,7 +851,7 @@ fn bigram_overlay_coherence_full_lifecycle_seed_edit_commit_rescan_edit() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(name));
+            picker.handle_create_or_modify(base.join(name));
         }
         phase1_tokens.push(token);
     }
@@ -930,7 +930,7 @@ fn bigram_overlay_coherence_full_lifecycle_seed_edit_commit_rescan_edit() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(name));
+            picker.handle_create_or_modify(base.join(name));
         }
         phase3_tokens.push(token);
     }
@@ -1009,7 +1009,7 @@ fn bigram_overlay_coherence_nested_directory_edits() {
         {
             let mut guard = shared_picker.write().unwrap();
             let picker = guard.as_mut().unwrap();
-            picker.on_create_or_modify(base.join(name));
+            picker.handle_create_or_modify(base.join(name));
         }
         edited.push(token);
     }
@@ -1127,7 +1127,7 @@ fn bigram_overlay_coherence_fuzzy_search_base_overflow_and_deleted() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(base.join("controller_admin.rs"));
+        picker.handle_create_or_modify(base.join("controller_admin.rs"));
     }
 
     // Fuzzy search should find the new overflow file.
@@ -1174,7 +1174,7 @@ fn bigram_overlay_coherence_fuzzy_search_after_rescan() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(base.join("router_grpc.rs"));
+        picker.handle_create_or_modify(base.join("router_grpc.rs"));
     }
 
     let web_path = base.join("router_web.rs");
@@ -1239,7 +1239,7 @@ fn bigram_overlay_coherence_fuzzy_and_grep_combined() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(base.join(edit_name));
+        picker.handle_create_or_modify(base.join(edit_name));
     }
 
     // Add an overflow file with a distinctive name.
@@ -1251,7 +1251,7 @@ fn bigram_overlay_coherence_fuzzy_and_grep_combined() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        picker.on_create_or_modify(base.join("unique_overflow_widget.rs"));
+        picker.handle_create_or_modify(base.join("unique_overflow_widget.rs"));
     }
 
     // Delete a base file.
@@ -1635,7 +1635,7 @@ fn bigram_overlay_coherence_fuzzy_grep_finds_overflow_files() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        assert!(picker.on_create_or_modify(&new_path).is_some());
+        assert!(picker.handle_create_or_modify(&new_path).is_some());
         assert_eq!(picker.get_overflow_files().len(), 1);
     }
 

--- a/crates/fff-core/tests/bigram_overlay_integration.rs
+++ b/crates/fff-core/tests/bigram_overlay_integration.rs
@@ -113,7 +113,7 @@ fn modified_file_findable_via_overlay() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        let result = picker.on_create_or_modify(&modified_path);
+        let result = picker.handle_create_or_modify(&modified_path);
         assert!(
             result.is_some(),
             "on_create_or_modify should return the file"
@@ -273,7 +273,7 @@ fn new_file_findable_after_add() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        let result = picker.on_create_or_modify(&new_path);
+        let result = picker.handle_create_or_modify(&new_path);
         assert!(
             result.is_some(),
             "on_create_or_modify should return the new file"
@@ -350,7 +350,7 @@ fn modified_file_findable_via_regex_overlay() {
     {
         let mut guard = shared_picker.write().unwrap();
         let picker = guard.as_mut().unwrap();
-        assert!(picker.on_create_or_modify(&modified_path).is_some());
+        assert!(picker.handle_create_or_modify(&modified_path).is_some());
     }
 
     // Regex grep should find the modified file through the overlay.

--- a/crates/fff-core/tests/fuzz_file_operations.rs
+++ b/crates/fff-core/tests/fuzz_file_operations.rs
@@ -379,7 +379,7 @@ fn fuzz_file_operations_stress() {
                 let mut guard = shared_picker.write().unwrap();
                 let picker = guard.as_mut().unwrap();
                 assert!(
-                    picker.on_create_or_modify(base.join(name)).is_some(),
+                    picker.handle_create_or_modify(base.join(name)).is_some(),
                     "round {round}: on_create_or_modify({name}) should succeed for edit"
                 );
             }
@@ -399,7 +399,7 @@ fn fuzz_file_operations_stress() {
                 let mut guard = shared_picker.write().unwrap();
                 let picker = guard.as_mut().unwrap();
                 assert!(
-                    picker.on_create_or_modify(base.join(&name)).is_some(),
+                    picker.handle_create_or_modify(base.join(&name)).is_some(),
                     "round {round}: on_create_or_modify({name}) should succeed for create"
                 );
             }
@@ -453,7 +453,9 @@ fn fuzz_file_operations_stress() {
                 let mut guard = shared_picker.write().unwrap();
                 let picker = guard.as_mut().unwrap();
                 assert!(
-                    picker.on_create_or_modify(base.join(&new_name)).is_some(),
+                    picker
+                        .handle_create_or_modify(base.join(&new_name))
+                        .is_some(),
                     "round {round}: on_create_or_modify({new_name}) should succeed for rename"
                 );
             }

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 06
+                              For Neovim >= 0.10.0    Last change: 2026 May 07
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*


### PR DESCRIPTION
closes https://github.com/dmtrKovalenko/fff/issues/453
closes https://github.com/dmtrKovalenko/fff/issues/453

This is essentially a problem I commited myself into by doing unsafe dirt, and it actaully blew us in a few releases. This set of changes making sure that we **guarantee** that the invalid behavior is impossibe at runtime, while still doing unsafe dirt in compile time.