### PR TITLE
Feat: Add an option to make changing window directory with `lcd` work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ require('fff').setup({
   max_threads = 4,
   lazy_sync = true,
   prompt_vim_mode = false,
-  change_local_directory = false,
+  change_index_cwd_on_lcd = false,
   layout = {
     height = 0.8,
     width = 0.8,

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ require('fff').setup({
   max_threads = 4,
   lazy_sync = true,
   prompt_vim_mode = false,
+  change_local_directory = false,
   layout = {
     height = 0.8,
     width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -199,7 +199,7 @@ local function init()
     max_threads = 4,
     lazy_sync = true, -- set to false if you want file indexing to start on open
     prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
-    change_index_cwd_on_lcd = false,
+    change_index_cwd_on_lcd = false, -- set to true if you want the picker to index from the current local working directory (:h lcd).
     layout = {
       height = 0.8,
       width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -197,9 +197,9 @@ local function init()
     title = 'FFFiles',
     max_results = 100,
     max_threads = 4,
-    change_local_directory = false,
     lazy_sync = true, -- set to false if you want file indexing to start on open
     prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
+    change_index_cwd_on_lcd = false,
     layout = {
       height = 0.8,
       width = 0.8,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -197,6 +197,7 @@ local function init()
     title = 'FFFiles',
     max_results = 100,
     max_threads = 4,
+    change_local_directory = false,
     lazy_sync = true, -- set to false if you want file indexing to start on open
     prompt_vim_mode = false, -- set to true to enable vim-mode in the prompt: <Esc> leaves insert for normal mode bindings (also allows <leader>p or <leader>l to jump around) the second <Esc> closes the picker
     layout = {

--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -46,7 +46,7 @@ local function setup_global_autocmds(config)
   vim.api.nvim_create_autocmd('DirChanged', {
     group = group,
     callback = function()
-      if vim.v.event.scope == 'window' and config.change_local_directory == false then return end
+      if vim.v.event.scope == 'window' and config.change_index_cwd_on_lcd  == false then return end
       if not state.initialized then return end
 
       local new_cwd = vim.v.event.cwd

--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -46,10 +46,7 @@ local function setup_global_autocmds(config)
   vim.api.nvim_create_autocmd('DirChanged', {
     group = group,
     callback = function()
-      -- Window-local `:lcd` / `:tcd` are per-window — they don't change the
-      -- effective project root for the picker, so bail before touching
-      -- anything else.
-      if vim.v.event.scope == 'window' then return end
+      if vim.v.event.scope == 'window' and config.change_local_directory == false  then return end
       if not state.initialized then return end
 
       local new_cwd = vim.v.event.cwd

--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -46,7 +46,7 @@ local function setup_global_autocmds(config)
   vim.api.nvim_create_autocmd('DirChanged', {
     group = group,
     callback = function()
-      if vim.v.event.scope == 'window' and config.change_local_directory == false  then return end
+      if vim.v.event.scope == 'window' and config.change_local_directory == false then return end
       if not state.initialized then return end
 
       local new_cwd = vim.v.event.cwd

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2713,7 +2713,8 @@ end
 --- @param opts table|nil Options passed to the picker
 --- @return table|nil, string|nil Merged configuration and base path, nil config if initialization failed
 local function initialize_picker(opts)
-  local base_path = opts and opts.cwd or vim.uv.cwd()
+  local config = require('fff.conf').get()
+  local base_path = (opts and opts.cwd) or (config.change_local_directory and vim.fn.getcwd(0)) or vim.uv.cwd()
 
   -- Initialize file picker if needed
   if not file_picker.is_initialized() then

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2714,7 +2714,7 @@ end
 --- @return table|nil, string|nil Merged configuration and base path, nil config if initialization failed
 local function initialize_picker(opts)
   local config = require('fff.conf').get()
-  local base_path = (opts and opts.cwd) or (config.change_local_directory and vim.fn.getcwd(0)) or vim.uv.cwd()
+  local base_path = (opts and opts.cwd) or (config.change_index_cwd_on_lcd  and vim.fn.getcwd(0)) or vim.uv.cwd()
 
   -- Initialize file picker if needed
   if not file_picker.is_initialized() then


### PR DESCRIPTION
I think the best way to explain this PR is to show my workflow.

I have this `autocmd` where I `lcd` into the directory I navigate to using `oil.nvim`:
```lua
local oil_local_cwd = vim.api.nvim_create_augroup("OilLocalCwd", { clear = true })
autocmd("BufEnter", {
    group = oil_local_cwd,
    callback = function(o)
        if o.match:find("^oil://") then
            vim.cmd.lcd(require("oil").get_current_dir())
        else
            vim.cmd.lcd(vim.fn.getcwd(-1))
        end
    end,
    nested = true
})
```
This is mainly for when I execute a command it execute in that directory. However, this breaks `fff` when I search for a file from `oil.nvim`:

<img width="950" height="42" alt="image" src="https://github.com/user-attachments/assets/75711987-9e72-45d1-a32b-ad429dbdcdd6" />
 
With this patch I introduced a new config option `change_local_directory` (I couldn't find a better name) that uses the window directory.

I hope that was clear.