### PR TITLE
feat(nix): expose fff-mcp flake package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         cargoToml = builtins.fromTOML (builtins.readFile ./crates/fff-nvim/Cargo.toml);
+        fffMcpCargoToml = builtins.fromTOML (builtins.readFile ./crates/fff-mcp/Cargo.toml);
 
         # Common arguments can be set here to avoid repeating them later
         # Note: changes here will rebuild all dependency crates
@@ -81,6 +82,21 @@
             doCheck = false;
           }
         );
+
+        fff-mcp-args = commonArgs // {
+          pname = fffMcpCargoToml.package.name;
+          version = fffMcpCargoToml.package.version;
+          cargoExtraArgs = "-p fff-mcp --bin fff-mcp";
+        };
+
+        fff-mcp = craneLib.buildPackage (
+          fff-mcp-args
+          // {
+            cargoArtifacts = craneLib.buildDepsOnly fff-mcp-args;
+            doCheck = false;
+          }
+        );
+
         # Copies the dynamic library into the target/release folder
         copy-dynamic-library = /* bash */ ''
           set -eo pipefail
@@ -95,11 +111,12 @@
       in
       {
         checks = {
-          inherit my-crate;
+          inherit my-crate fff-mcp;
         };
 
         packages = {
           default = my-crate;
+          inherit fff-mcp;
 
           # Neovim plugin
           fff-nvim = pkgs.vimUtils.buildVimPlugin {
@@ -113,6 +130,10 @@
 
         apps.default = flake-utils.lib.mkApp {
           drv = my-crate;
+        };
+
+        apps.fff-mcp = flake-utils.lib.mkApp {
+          drv = fff-mcp;
         };
 
         # Add the release command


### PR DESCRIPTION
Adds a `fff-mcp` package to the flake.nix for `aarch64-darwin`, `aarch64-linux`, `x86_64-linux`, and `x86_64-linux`. This allows people to import the `dmtrKovalenko/fff` flake to include the mcp server in their nix-based projects and system configurations.

To validate

<details>
<summary><pre><code>nix flake show</code></pre></summary>
<pre><code>
❯ nix flake show --all-systems
git+file:///Users/cmcbride/homebase/code/github.com/carterworks/fff?ref=refs/heads/add-fff-mcp-flake-package&rev=32ce7b0310953497092136b4121249bf81656529
├───apps
│   ├───aarch64-darwin
│   │   ├───default: app: no description
│   │   ├───fff-mcp: app: no description
│   │   └───release: app: no description
│   ├───aarch64-linux
│   │   ├───default: app: no description
│   │   ├───fff-mcp: app: no description
│   │   └───release: app: no description
│   ├───x86_64-darwin
│   │   ├───default: app: no description
│   │   ├───fff-mcp: app: no description
│   │   └───release: app: no description
│   └───x86_64-linux
│       ├───default: app: no description
│       ├───fff-mcp: app: no description
│       └───release: app: no description
├───checks
│   ├───aarch64-darwin
│   │   ├───fff-mcp: derivation 'fff-mcp-0.7.2'
│   │   └───my-crate: derivation 'fff-nvim-0.7.2'
│   ├───aarch64-linux
│   │   ├───fff-mcp: derivation 'fff-mcp-0.7.2'
│   │   └───my-crate: derivation 'fff-nvim-0.7.2'
│   ├───x86_64-darwin
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
│   │   ├───fff-mcp: derivation 'fff-mcp-0.7.2'
│   │   └───my-crate: derivation 'fff-nvim-0.7.2'
│   └───x86_64-linux
│       ├───fff-mcp: derivation 'fff-mcp-0.7.2'
│       └───my-crate: derivation 'fff-nvim-0.7.2'
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
└───packages
    ├───aarch64-darwin
    │   ├───default: package 'fff-nvim-0.7.2'
    │   ├───fff-mcp: package 'fff-mcp-0.7.2'
    │   └───fff-nvim: package 'vimplugin-fff.nvim-main'
    ├───aarch64-linux
    │   ├───default: package 'fff-nvim-0.7.2'
    │   ├───fff-mcp: package 'fff-mcp-0.7.2'
    │   └───fff-nvim: package 'vimplugin-fff.nvim-main'
    ├───x86_64-darwin
    │   ├───default: package 'fff-nvim-0.7.2'
    │   ├───fff-mcp: package 'fff-mcp-0.7.2'
    │   └───fff-nvim: package 'vimplugin-fff.nvim-main'
    └───x86_64-linux
        ├───default: package 'fff-nvim-0.7.2'
        ├───fff-mcp: package 'fff-mcp-0.7.2'
        └───fff-nvim: package 'vimplugin-fff.nvim-main'
</code></pre>
</details>

<details>
<summary><pre><code>time nix build .#fff-mcp</code></pre></summary>
<pre><code>
fff via 🥟 v1.3.13 via 🌙 via 🦀 on  add-fff-mcp-flake-package took 5s
❯ time nix build .#fff-mcp

________________________________________________________
Executed in  491.62 secs      fish           external
   usr time   78.72 millis    0.22 millis   78.50 millis
   sys time   72.45 millis    1.68 millis   70.77 millis


fff via 🥟 v1.3.13 via 🌙 via 🦀 on  add-fff-mcp-flake-package
❯ ./result/bin/fff-mcp --help
FFF MCP Server — high-performance file finder for AI code assistants

Usage: fff-mcp [OPTIONS] [PATH] [NO_CONTENT_INDEXING]

Arguments:
  [PATH]                 Base directory to index. Defaults to the current working directory
  [NO_CONTENT_INDEXING]  Disable the content index built after the initial scan. This makes grep calls slower but consumes less RAM (recommended to not turn off)

Options:
      --frecency-db <FRECENCY_DB_PATH>
          Path to the frecency database
      --history-db <HISTORY_DB_PATH>
          Path to the query history database
      --log-file <LOG_FILE>
          Path to the log file
      --log-level <LOG_LEVEL>
          Log level (e.g. trace, debug, info, warn, error)
      --no-update-check
          Disable automatic update checks on startup
      --no-warmup
          Disable eager mmap warmup after the initial scan. Grep results will still work (files are mmap'd lazily on first access), but the first search may be slightly slower. Useful on very large repos where the warmup would consume too many kernel resources
      --content-indexing
          Explicitly enable content indexing even when `--no-warmup` is set
      --no-watch
          Disable the background file-system watcher. Files are scanned once at startup but not monitored for changes
      --max-cached-files <MAX_CACHED_FILES>
          Maximum number of files whose content is kept persistently in memory. Files beyond this limit are still searchable via temporary mmaps that are released after each grep. Defaults to 30 000. Also settable via the FFF_MAX_CACHED_FILES environment variable [env: FFF_MAX_CACHED_FILES=]
      --healthcheck
          Run a health check and print diagnostic information, then exit
  -h, --help
          Print help
  -V, --version
          Print version

fff via 🥟 v1.3.13 via 🌙 via 🦀 on  add-fff-mcp-flake-package
❯ ./result/bin/fff-mcp --version
fff-mcp 0.7.2 (unknown)
</pre></code>
</details>