### PR TITLE
fix(pi-fff): preserve editor in tools-only mode

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -464,14 +464,12 @@ export default function fffExtension(pi: ExtensionAPI) {
       ) => void;
     };
   }) {
-    if (!shouldEnableMentions()) {
-      ctx.ui.setEditorComponent(undefined);
-    } else {
-      ctx.ui.setEditorComponent(
-        (tui: any, theme: any, keybindings: any) =>
-          new FffEditor(tui, theme, keybindings),
-      );
-    }
+    if (!shouldEnableMentions()) return;
+
+    ctx.ui.setEditorComponent(
+      (tui: any, theme: any, keybindings: any) =>
+        new FffEditor(tui, theme, keybindings),
+    );
   }
 
   // --- Flags / lifecycle ---


### PR DESCRIPTION
## Summary
- similar to #454, this fixes another tools-only path where pi-fff could still overwrite the editor