### PR TITLE
fix: allow ffgrep path constraint outside workspace (#463)

### DIFF
--- a/packages/pi-fff/src/query.ts
+++ b/packages/pi-fff/src/query.ts
@@ -10,10 +10,9 @@ export function normalizePathConstraint(
   if (path.isAbsolute(trimmed)) {
     const relative = path.relative(cwd, trimmed).replaceAll(path.sep, "/");
     if (relative === "") return null;
+    // Allow absolute paths outside workspace - pass through unchanged
     if (relative.startsWith("../") || relative === ".." || path.isAbsolute(relative)) {
-      throw new Error(
-        `Path constraint must be relative to the workspace: ${pathConstraint}`,
-      );
+      return trimmed.replaceAll(path.sep, "/");
     }
     trimmed = relative;
   }

--- a/packages/pi-fff/test/query.test.ts
+++ b/packages/pi-fff/test/query.test.ts
@@ -11,9 +11,12 @@ describe("path constraint normalization", () => {
     );
   });
 
-  test("rejects absolute paths outside the workspace", () => {
-    expect(() => normalizePathConstraint("/tmp/other/.agents/**", cwd)).toThrow(
-      "Path constraint must be relative to the workspace",
+  test("allows absolute paths outside the workspace", () => {
+    expect(normalizePathConstraint("/tmp/other/.agents/**", cwd)).toBe(
+      "/tmp/other/.agents/**",
+    );
+    expect(normalizePathConstraint("/home/user/.pi/docs/", cwd)).toBe(
+      "/home/user/.pi/docs/",
     );
   });
 


### PR DESCRIPTION
Closes #463

## Root cause

MCP tool `ffgrep` enforces workspace-relative paths via `normalizePathConstraint()` (packages/pi-fff/src/query.ts:13-17). When user provides absolute path outside workspace, path.relative() returns `../...`. Current code throws error. FFF Rust core accepts absolute paths - constraint is TypeScript-layer only.

## Fix

Modified `normalizePathConstraint()` to pass through absolute paths outside workspace unchanged. Inside-workspace paths still get relativized. FFF core handles both.

## Steps to reproduce

Pre-fix behavior on `origin/main`:

```sh
cd /Users/neogoose/dev/__scripts/triage-workspace/fff/packages/pi-fff

# Run test showing rejection
bun test

# Test at line 14-18 shows:
# test("rejects absolute paths outside the workspace", () => {
#   expect(() => normalizePathConstraint("/tmp/other/.agents/**", cwd)).toThrow(
#     "Path constraint must be relative to the workspace",
#   );
# });

# Manual repro - create test file
cat > repro.ts << 'REPRO'
import { normalizePathConstraint } from "./src/query";

const cwd = "/tmp/workspace";
try {
  const result = normalizePathConstraint("/home/user/.pi/docs/", cwd);
  console.log("Result:", result);
} catch (e) {
  console.error("Error:", e.message);
}
REPRO

bun repro.ts
# Expected (pre-fix): Error: Path constraint must be relative to the workspace: /home/user/.pi/docs/
# Actual (post-fix): Result: /home/user/.pi/docs/
```

Post-fix on this branch:

```sh
git checkout triage-bot/issue-463
cd packages/pi-fff
bun test
# All tests pass - rejection test replaced with acceptance test

bun repro.ts
# Result: /home/user/.pi/docs/
```

## How verified

- Updated test suite: replaced rejection test with acceptance test for outside-workspace paths
- Ran `bun test` - all 10 tests pass (22 assertions)
- Manual verification: outside-workspace paths return absolute path unchanged, inside-workspace paths still get relativized correctly

Automated triage via gustav-fff bot.