### PR TITLE
fix: Add allowlist and denylist to FilePickerOptions (#448)

### DIFF
--- a/crates/fff-c/src/lib.rs
+++ b/crates/fff-c/src/lib.rs
@@ -270,6 +270,8 @@ pub unsafe extern "C" fn fff_create_instance2(
             watch,
             mode,
             cache_budget,
+            allowlist: Vec::new(),
+            denylist: Vec::new(),
         },
     ) {
         return FffResult::err(&format!("Failed to init file picker: {}", e));
@@ -924,6 +926,8 @@ pub unsafe extern "C" fn fff_restart_index(
             watch,
             mode,
             cache_budget: None,
+            allowlist: Vec::new(),
+            denylist: Vec::new(),
         },
     ) {
         Ok(()) => FffResult::ok_empty(),

--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -444,6 +444,10 @@ pub struct FilePickerOptions {
     pub cache_budget: Option<ContentCacheBudget>,
     /// When `false`, `new_with_shared_state` skips the background file watcher.
     pub watch: bool,
+    /// Glob patterns to include during indexing. Empty = include all.
+    pub allowlist: Vec<String>,
+    /// Glob patterns to exclude during indexing. Applied after allowlist.
+    pub denylist: Vec<String>,
 }
 
 impl Default for FilePickerOptions {
@@ -455,6 +459,8 @@ impl Default for FilePickerOptions {
             mode: FFFMode::default(),
             cache_budget: None,
             watch: true,
+            allowlist: Vec::new(),
+            denylist: Vec::new(),
         }
     }
 }
@@ -471,6 +477,8 @@ pub struct FilePicker {
     enable_mmap_cache: bool,
     enable_content_indexing: bool,
     watch: bool,
+    allowlist: Vec<String>,
+    denylist: Vec<String>,
 }
 
 impl std::fmt::Debug for FilePicker {
@@ -526,6 +534,14 @@ impl FilePicker {
 
     pub fn mode(&self) -> FFFMode {
         self.mode
+    }
+
+    pub fn allowlist(&self) -> &[String] {
+        &self.allowlist
+    }
+
+    pub fn denylist(&self) -> &[String] {
+        &self.denylist
     }
 
     pub fn cache_budget(&self) -> &ContentCacheBudget {
@@ -717,6 +733,8 @@ impl FilePicker {
             enable_mmap_cache: options.enable_mmap_cache,
             enable_content_indexing: options.enable_content_indexing,
             watch: options.watch,
+            allowlist: options.allowlist,
+            denylist: options.denylist,
         })
     }
 
@@ -745,6 +763,8 @@ impl FilePicker {
         let signals = picker.scan_signals();
         let scanned_files_counter = picker.scanned_files_counter();
         let path = picker.base_path.clone();
+        let allowlist = picker.allowlist.clone();
+        let denylist = picker.denylist.clone();
 
         {
             let mut guard = shared_picker.write()?;
@@ -768,6 +788,8 @@ impl FilePicker {
                 auto_cache_budget: true,
                 install_watcher: true,
             },
+            allowlist,
+            denylist,
         )
         .spawn();
 
@@ -796,6 +818,8 @@ impl FilePicker {
             &self.scanned_files_count,
             &empty_frecency,
             self.mode,
+            &self.allowlist,
+            &self.denylist,
         )?;
 
         self.sync_data = sync;
@@ -1711,11 +1735,39 @@ impl FileSync {
         synced_files_count: &Arc<AtomicUsize>,
         shared_frecency: &SharedFrecency,
         mode: FFFMode,
+        allowlist: &[String],
+        denylist: &[String],
     ) -> Result<FileSync, Error> {
         use ignore::WalkBuilder;
+        use globset::{Glob, GlobSetBuilder};
 
         let scan_start = std::time::Instant::now();
         info!("SCAN: Starting filesystem walk and git status (async)");
+
+        // Build globsets for filtering
+        let allowlist_set = if !allowlist.is_empty() {
+            let mut builder = GlobSetBuilder::new();
+            for pattern in allowlist {
+                if let Ok(glob) = Glob::new(pattern) {
+                    builder.add(glob);
+                }
+            }
+            builder.build().ok()
+        } else {
+            None
+        };
+
+        let denylist_set = if !denylist.is_empty() {
+            let mut builder = GlobSetBuilder::new();
+            for pattern in denylist {
+                if let Ok(glob) = Glob::new(pattern) {
+                    builder.add(glob);
+                }
+            }
+            builder.build().ok()
+        } else {
+            None
+        };
 
         // Walk files (the fast part, typically 2-3s even on huge repos).
         let is_git_repo = git_workdir.is_some();
@@ -1749,6 +1801,8 @@ impl FileSync {
             let pairs = &pairs;
             let counter = Arc::clone(synced_files_count);
             let base_path = base_path.to_path_buf();
+            let allowlist_set = allowlist_set.clone();
+            let denylist_set = denylist_set.clone();
 
             Box::new(move |result| {
                 let Ok(entry) = result else {
@@ -1766,6 +1820,20 @@ impl FileSync {
 
                     if !is_git_repo && is_known_binary_extension(path) {
                         return ignore::WalkState::Continue;
+                    }
+
+                    // Apply allowlist/denylist filtering
+                    if let Ok(rel_path) = path.strip_prefix(&base_path) {
+                        if let Some(ref allow_set) = allowlist_set {
+                            if !allow_set.is_match(rel_path) {
+                                return ignore::WalkState::Continue;
+                            }
+                        }
+                        if let Some(ref deny_set) = denylist_set {
+                            if deny_set.is_match(rel_path) {
+                                return ignore::WalkState::Continue;
+                            }
+                        }
                     }
 
                     let metadata = entry.metadata().ok();

--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -1738,8 +1738,8 @@ impl FileSync {
         allowlist: &[String],
         denylist: &[String],
     ) -> Result<FileSync, Error> {
-        use ignore::WalkBuilder;
         use globset::{Glob, GlobSetBuilder};
+        use ignore::WalkBuilder;
 
         let scan_start = std::time::Instant::now();
         info!("SCAN: Starting filesystem walk and git status (async)");

--- a/crates/fff-core/src/scan.rs
+++ b/crates/fff-core/src/scan.rs
@@ -57,6 +57,8 @@ pub(crate) struct ScanJob {
     /// side. Reset to 0 at scan start, incremented per-file by the
     /// walker. Shared `Arc` so the UI polls the same atomic.
     scanned_files_counter: Arc<AtomicUsize>,
+    allowlist: Vec<String>,
+    denylist: Vec<String>,
 }
 
 impl ScanJob {
@@ -80,6 +82,8 @@ impl ScanJob {
         let signals = picker.scan_signals();
         let scanned_files_counter = picker.scanned_files_counter();
         let base_path = picker.base_path().to_path_buf();
+        let allowlist = picker.allowlist().to_vec();
+        let denylist = picker.denylist().to_vec();
 
         let new_scan_config = ScanConfig {
             warmup: picker.has_mmap_cache(),
@@ -99,6 +103,8 @@ impl ScanJob {
             config: new_scan_config,
             shared_picker: shared_picker.clone(),
             shared_frecency: shared_frecency.clone(),
+            allowlist,
+            denylist,
         }))
     }
 
@@ -110,6 +116,8 @@ impl ScanJob {
         signals: ScanSignals,
         scanned_files_counter: Arc<AtomicUsize>,
         config: ScanConfig,
+        allowlist: Vec<String>,
+        denylist: Vec<String>,
     ) -> Self {
         Self {
             shared_picker,
@@ -119,6 +127,8 @@ impl ScanJob {
             signals,
             scanned_files_counter,
             config,
+            allowlist,
+            denylist,
         }
     }
 
@@ -140,6 +150,8 @@ impl ScanJob {
             signals,
             scanned_files_counter,
             config,
+            allowlist,
+            denylist,
         } = self;
 
         let _scanning = ScanningGuard::new(&signals, config.install_watcher);
@@ -157,6 +169,8 @@ impl ScanJob {
             &scanned_files_counter,
             &shared_frecency,
             mode,
+            &allowlist,
+            &denylist,
         ) {
             Ok(sync) => sync,
             Err(e) => {

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -269,6 +269,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             cache_budget: args
                 .max_cached_files
                 .map(fff::ContentCacheBudget::new_for_repo),
+            allowlist: Vec::new(),
+            denylist: Vec::new(),
         },
     )
     .map_err(|e| format!("Failed to init file picker: {}", e))?;


### PR DESCRIPTION
Closes #448

## Root cause
`FilePickerOptions` had no mechanism to scope indexing. Reporter noted that `exclude_dir` in fff-gpui filters post-index but still walks entire tree. Requested allowlist/denylist to reduce indexing footprint.

## Fix
- Added `allowlist: Vec<String>` and `denylist: Vec<String>` fields to `FilePickerOptions`
- Stored in `FilePicker` struct, threaded through `ScanJob` to `walk_filesystem`
- Built `GlobSet` from patterns at walk start
- Applied filtering in parallel walker callback via `globset::is_match` on relative paths
- Allowlist checked first (if non-empty), then denylist

## Steps to reproduce
1. Build project: `make build` from repo root
2. Create test directory with mixed files:
   ```sh
   mkdir -p /tmp/fff-test/{src,dist,node_modules}
   touch /tmp/fff-test/src/main.rs
   touch /tmp/fff-test/dist/bundle.js
   touch /tmp/fff-test/node_modules/lodash.js
   ```
3. Test without filter (baseline):
   ```rust
   let picker = FilePicker::new(FilePickerOptions {
       base_path: "/tmp/fff-test".into(),
       ..Default::default()
   })?;
   picker.collect_files()?;
   // Observe all files indexed
   ```
4. Test with denylist:
   ```rust
   let picker = FilePicker::new(FilePickerOptions {
       base_path: "/tmp/fff-test".into(),
       denylist: vec!["**/node_modules/**".into(), "**/dist/**".into()],
       ..Default::default()
   })?;
   picker.collect_files()?;
   // Verify only src/main.rs indexed
   ```
5. Test with allowlist:
   ```rust
   let picker = FilePicker::new(FilePickerOptions {
       base_path: "/tmp/fff-test".into(),
       allowlist: vec!["**/*.rs".into()],
       ..Default::default()
   })?;
   picker.collect_files()?;
   // Verify only Rust files indexed
   ```

## How verified
- `cargo build --manifest-path Cargo.toml` — compiles clean
- `cargo test --lib` — all 90 unit tests pass
- Diff size: 88 LOC (4 files)

Automated triage via gustav-fff bot.