### PR TITLE
fix: restore user control over treesitter in preview (#367)

### DIFF
--- a/lua/fff/file_picker/preview.lua
+++ b/lua/fff/file_picker/preview.lua
@@ -10,28 +10,6 @@ local M = {}
 -- Namespace dedicated to the file info panel highlights.
 M.file_info_ns = vim.api.nvim_create_namespace('fff_file_info')
 
--- Preview buffers are scratch buffers. Detect the file's language and attach
--- highlighting directly, but keep buffer filetype empty to avoid ftplugin and
--- LSP side effects that are meant for real editing buffers.
-local function attach_preview_highlighter(bufnr, filetype)
-  if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then return end
-
-  pcall(vim.treesitter.stop, bufnr)
-  vim.api.nvim_set_option_value('filetype', '', { buf = bufnr })
-  vim.api.nvim_set_option_value('syntax', '', { buf = bufnr })
-
-  if not filetype or filetype == '' then return end
-
-  local lang_ok, lang = pcall(vim.treesitter.language.get_lang, filetype)
-  if not lang_ok or not lang then lang = filetype end
-
-  if pcall(vim.treesitter.language.add, lang) then
-    pcall(vim.treesitter.start, bufnr, lang)
-  else
-    vim.api.nvim_set_option_value('syntax', filetype, { buf = bufnr })
-  end
-end
-
 local function set_buffer_lines(bufnr, lines)
   if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then return end
 
@@ -300,7 +278,7 @@ local function link_buffer_content(source_bufnr, target_bufnr)
   set_buffer_lines(target_bufnr, lines)
 
   local source_ft = vim.api.nvim_get_option_value('filetype', { buf = source_bufnr })
-  if source_ft ~= '' then attach_preview_highlighter(target_bufnr, source_ft) end
+  if source_ft ~= '' then vim.api.nvim_set_option_value('filetype', source_ft, { buf = target_bufnr }) end
 
   M.state.has_more_content = false
   M.state.total_file_lines = #lines
@@ -456,7 +434,7 @@ function M.preview_file(file_path, bufnr)
       set_buffer_lines(bufnr, content)
 
       local file_config = M.get_file_config(file_path)
-      attach_preview_highlighter(bufnr, info.filetype)
+      vim.api.nvim_set_option_value('filetype', info.filetype, { buf = bufnr })
       vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
       vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
       vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
@@ -575,7 +553,7 @@ function M.preview_binary_file(file_path, bufnr)
   end
 
   set_buffer_lines(bufnr, lines)
-  attach_preview_highlighter(bufnr, 'text')
+  vim.api.nvim_set_option_value('filetype', 'text', { buf = bufnr })
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
   vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
 
@@ -858,8 +836,11 @@ function M.clear_buffer(bufnr)
   cleanup_file_operation()
   M.clear_preview_visual_state(bufnr)
 
+  pcall(vim.treesitter.stop, bufnr)
+
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
-  attach_preview_highlighter(bufnr, '')
+  vim.api.nvim_set_option_value('filetype', '', { buf = bufnr })
+  vim.api.nvim_set_option_value('syntax', '', { buf = bufnr })
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
 
   set_buffer_lines(bufnr, {})


### PR DESCRIPTION
Closes #367

## Root cause
PR #335 introduced `attach_preview_highlighter()` which unconditionally calls `vim.treesitter.start(bufnr, lang)` at lua/fff/file_picker/preview.lua:24. Users lost control over treesitter highlighting in preview buffers. Before #335, setting filetype triggered ftplugin events where users conditionally started treesitter based on file size/parser performance. After #335, treesitter forced on regardless, causing UI lag with slow parsers or large files.

## Fix
Removed `attach_preview_highlighter()` function (22 lines). Restored direct filetype setting without forced treesitter start at 4 call sites (lines 274, 532, 651, 838). Buffer already protected via `buftype=nofile`. Plugins must check `buftype` in ftplugin to avoid loading in scratch buffers (standard neovim practice per `:h filetype`). Misbehaving plugins (like Merlin from #335) should be fixed upstream to check `buftype`, not worked around by forcing highlighting off in fff.

## Steps to reproduce

**Pre-fix (current main):**
```bash
git checkout origin/main
```

Create test ftplugin to observe treesitter control:
```bash
mkdir -p ~/.config/nvim/after/ftplugin
cat > ~/.config/nvim/after/ftplugin/lua.lua <<'FTPLUGIN'
-- User ftplugin: conditionally start treesitter for lua files
if vim.bo.buftype ~= '' then
  -- Skip non-file buffers (preview, quickfix, etc)
  return
end

local line_count = vim.api.nvim_buf_line_count(0)
if line_count > 500 then
  print("Skipping treesitter for large file: " .. line_count .. " lines")
  return
end

vim.treesitter.start()
print("Started treesitter for small file: " .. line_count .. " lines")
FTPLUGIN
```

Start neovim in test directory with lua files:
```bash
cd /path/to/repo/with/lua/files
nvim
```

Open fff picker on a large lua file (>500 lines):
```vim
:lua require('fff').find_files()
" Navigate to preview of large lua file (e.g., lua/fff/picker_ui.lua)
```

**Expected (user ftplugin controls treesitter):** "Skipping treesitter for large file" message, no treesitter highlighting in preview.

**Actual (on main):** Treesitter highlighting applied regardless, ftplugin message never fires. Preview lags on large file.

**Post-fix (this PR):**
```bash
git checkout triage-bot/issue-367
```
Repeat steps. Expected behavior: ftplugin runs, "Skipping treesitter" fires, no lag on large file preview.

## How verified
- Ran `make test`: 213 Rust unit tests pass, 23 Lua tests pass, 52 bun tests pass. Core functionality preserved.
- Ran `cargo clippy --workspace --features zlob -- -D warnings`: clean, no warnings.
- Verified diff: 33 lines changed (7 add, 26 del), single file modified. Minimal revert.
- Manual check: filetype still set for preview buffers (`vim.bo.filetype` populated), but `vim.treesitter.start` no longer forced. User ftplugin scripts now control treesitter activation.

Automated triage via gustav-fff bot.