### PR TITLE
docs: add Homebrew install for fff-mcp (#345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps
 
 The scripts live at [`install-mcp.sh`](./install-mcp.sh) and [`install-mcp.ps1`](./install-mcp.ps1) if you want to read them first.
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install gustav-fff/tap/fff-mcp
+```
+
+Community-maintained tap at [gustav-fff/homebrew-tap](https://github.com/gustav-fff/homebrew-tap). Pulls the prebuilt binary from the GitHub release assets.
+
 It prints the exact wiring instructions for your client. Once the server is connected, ask the agent to "use fff" and it picks up the `ffgrep`, `fffind`, and `fff-multi-grep` tools.
 
 ### Recommended agent prompt


### PR DESCRIPTION
Closes #345

## Root cause

Feature request, not a bug. Users wanted a familiar package-manager install path for `fff-mcp` instead of piping curl to bash.

## Fix

Published a Homebrew tap at [gustav-fff/homebrew-tap](https://github.com/gustav-fff/homebrew-tap) with `fff-mcp.rb` (formula adapted from @Aeron's tap, per maintainer instruction). Formula pulls the prebuilt binaries from the GitHub release assets of `dmtrKovalenko/fff.nvim` v0.8.1, with sha256 pins for darwin/linux × arm64/x86_64. README updated with one new section under MCP server install.

## Steps to reproduce

Pre-fix `main`: no Homebrew install path documented; only curl script.

```bash
grep -i homebrew README.md  # no match on origin/main
```

## How verified

```bash
brew install gustav-fff/tap/fff-mcp
which fff-mcp           # /opt/homebrew/Cellar/fff-mcp/0.8.1/bin/fff-mcp
fff-mcp --version       # fff-mcp 0.8.1 (6645a68ebc1f1a0dc98c1669a7e3f6d91625f79f)
fff-mcp --help          # prints usage
```

Tap installs cleanly on darwin-arm64. SHA256 values verified against `*.sha256` sidecar files on the v0.8.1 release.

Notes for maintainer:
- Tap lives under bot account `gustav-fff/homebrew-tap`. If you want canonical ownership, fork it under `dmtrKovalenko/homebrew-tap` and swap the tap path in README — formula is portable.
- Formula targets `fff-mcp` only (the user-facing binary). The `.dylib`/`.so`/`.dll` artifacts for the Neovim plugin remain installed via the plugin's own download step — Homebrew is not the right channel for them.
- Version is hard-pinned to 0.8.1. Bumping requires updating `version` + 4 sha256 fields in the tap, ideally automated from the release workflow.

Automated triage via Gustav. Honk-Honk 🪿