### PR TITLE
feat(picker): user mappings for input buffer (closes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ require('fff').setup({
     focus_list = '<leader>l',
     focus_preview = '<leader>p',
   },
+  -- Telescope-style user mappings on the input buffer, keyed by mode (`i` / `n`).
+  -- Values may be a function or a string (rhs). Applied on top of built-in keymaps.
+  mappings = {
+    i = {
+      -- ["<A-BS>"] = function() vim.api.nvim_input("<C-w>") end,
+    },
+    n = {},
+  },
   frecency = {
     enabled = true,
     db_path = vim.fn.stdpath('cache') .. '/fff_nvim',

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -69,6 +69,7 @@ local M = {}
 --- @field layout FffLayoutConfig
 --- @field preview FffPreviewConfig
 --- @field keymaps FffKeymapsConfig
+--- @field mappings table<string, table<string, function|string>> User-defined per-mode keymaps. Telescope-style: { i = { ["<A-BS>"] = fn }, n = { ... } }. Mapped on the input buffer.
 --- @field hl table<string, string>
 --- @field frecency FffFrecencyConfig
 --- @field history FffHistoryConfig
@@ -261,6 +262,16 @@ local function init()
       -- this are specific for the normal mode (you can exit it using any other keybind like jj)
       focus_list = '<leader>l',
       focus_preview = '<leader>p',
+    },
+    -- Telescope-style user mappings keyed by mode. Mapped on the input buffer.
+    -- Example:
+    --   mappings = {
+    --     i = { ["<A-BS>"] = function() vim.api.nvim_input("<C-w>") end },
+    --     n = { ["<C-r>"] = function() ... end },
+    --   }
+    mappings = {
+      i = {},
+      n = {},
     },
     hl = {
       border = 'FloatBorder',

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1195,6 +1195,13 @@ function M.setup_keymaps()
   set_keymap({ 'i', 'n' }, keymaps.send_to_quickfix, M.send_to_quickfix, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.cycle_grep_modes, M.cycle_grep_modes, input_opts)
 
+  local user_mappings = M.state.config.mappings or {}
+  for _, mode in ipairs({ 'i', 'n' }) do
+    for lhs, rhs in pairs(user_mappings[mode] or {}) do
+      if type(rhs) == 'function' or type(rhs) == 'string' then vim.keymap.set(mode, lhs, rhs, input_opts) end
+    end
+  end
+
   -- List buffer
   set_keymap('n', keymaps.close, M.close, list_opts)
   set_keymap('n', 'q', M.close, list_opts)


### PR DESCRIPTION
Closes #78

## Root cause
No way for users to bind arbitrary lhs->callback on input buffer. Only named-action keymaps exposed via `keymaps` config.

## Fix
New `mappings` config table, telescope-style, keyed by mode (`i` / `n`). Values are function or string rhs. Applied after built-in keymaps in `lua/fff/picker_ui.lua:1198`, so user mappings override defaults for the same lhs.

```lua
require('fff').setup({
  mappings = {
    i = {
      ["<A-BS>"] = function() vim.api.nvim_input("<C-w>") end,
    },
  },
})
```

## Steps to reproduce
Pre-fix `main`: no `mappings` field; setting `<A-BS>` to send `<C-w>` is impossible without monkey-patching `picker_ui.setup_keymaps`.

After fix:

```lua
-- minimal repro init
require('fff').setup({
  mappings = {
    i = {
      ["<A-BS>"] = function() vim.api.nvim_input("<C-w>") end,
    },
  },
})
vim.keymap.set('n', '<leader>ff', require('fff').find_files)
```

Open picker, insert mode, type `foo bar`, press `<A-BS>` -> deletes `bar` (word back). Without fix, `<A-BS>` does nothing or inserts a literal char.

## How verified
- stylua format clean
- Manual: keymap registration loop iterates `i` and `n`, type-checks rhs, calls `vim.keymap.set` with input buffer opts. Built-ins set first so user mappings win on conflict.

Scope intentionally minimal per @dmtrKovalenko direction. Only input buffer for now (matches issue spec). Could extend to list/preview buffers later if needed.

Automated triage via Gustav. Honk-Honk 🪿