### PR TITLE
feat: add oldfiles picker for recently opened files

### DIFF
--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -17,6 +17,23 @@ function M.find_files(opts)
   end
 end
 
+--- Find recently opened files (oldfiles)
+--- @param opts? table Optional configuration overrides
+function M.find_oldfiles(opts)
+  local picker_ok, picker_ui = pcall(require, 'fff.picker_ui')
+  if not picker_ok then
+    vim.notify('Failed to load picker UI: ' .. picker_ui, vim.log.levels.ERROR)
+    return
+  end
+
+  local picker_opts = vim.tbl_deep_extend('force', {
+    title = 'Recent Files',
+    mode = 'oldfiles',
+  }, opts or {})
+
+  picker_ui.open(picker_opts)
+end
+
 --- Live grep: search file contents in the current directory
 --- @param opts? {cwd?: string, title?: string, prompt?: string, layout?: table, grep?: {max_file_size?: number, smart_case?: boolean, max_matches_per_file?: number, modes?: string[]}, query?: string} Optional configuration overrides
 function M.live_grep(opts)

--- a/lua/fff/oldfiles.lua
+++ b/lua/fff/oldfiles.lua
@@ -1,0 +1,75 @@
+--- Oldfiles module for FFF
+--- Provides recent/old files list using vim.v.oldfiles as source
+local M = {}
+
+--- Build a FileItem-compatible table from a file path
+--- @param filepath string Absolute file path
+--- @param base_path string|nil Base path for computing relative_path
+--- @return table FileItem-compatible table
+local function build_file_item(filepath, base_path)
+  local name = vim.fn.fnamemodify(filepath, ':t')
+  local extension = vim.fn.fnamemodify(filepath, ':e')
+
+  local relative_path = filepath
+  if base_path and vim.startswith(filepath, base_path .. '/') then
+    relative_path = filepath:sub(#base_path + 2)
+  end
+
+  local stat = vim.uv.fs_stat(filepath)
+
+  return {
+    relative_path = relative_path,
+    name = name,
+    extension = extension,
+    size = stat and stat.size or 0,
+    modified = stat and stat.mtime and stat.mtime.sec or 0,
+    total_frecency_score = 0,
+    access_frecency_score = 0,
+    modification_frecency_score = 0,
+    git_status = nil,
+    is_binary = false,
+  }
+end
+
+--- Simple fuzzy match: all query chars must appear in order within the target
+--- @param query string Lowercase query
+--- @param target string Target string to match against
+--- @return boolean
+local function fuzzy_match(query, target)
+  if query == '' then return true end
+  local lower_target = target:lower()
+  local ti = 1
+  for qi = 1, #query do
+    local ch = query:sub(qi, qi)
+    local found = lower_target:find(ch, ti, true)
+    if not found then return false end
+    ti = found + 1
+  end
+  return true
+end
+
+--- Get oldfiles filtered by query
+--- @param query string Search query for filtering
+--- @param max_results number|nil Maximum results to return
+--- @return table[] List of FileItem-compatible tables
+function M.search(query, max_results)
+  max_results = max_results or 100
+  local lower_query = (query or ''):lower()
+  local results = {}
+
+  for _, filepath in ipairs(vim.v.oldfiles) do
+    if #results >= max_results then break end
+
+    local expanded = vim.fn.expand(filepath)
+    if vim.fn.filereadable(expanded) == 1 then
+      local display = vim.fn.fnamemodify(expanded, ':~')
+      if fuzzy_match(lower_query, display) then
+        table.insert(results, build_file_item(expanded, nil))
+      end
+    end
+  end
+
+  return results
+end
+
+return M

--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -1407,7 +1407,12 @@ function M.update_results_sync()
   end
 
   local results
-  if M.state.mode == 'grep' then
+  if M.state.mode == 'oldfiles' then
+    local oldfiles = require('fff.oldfiles')
+    results = oldfiles.search(M.state.query, page_size)
+    M.state.pagination.total_matched = #results
+    M.state.location = nil
+  elseif M.state.mode == 'grep' then
     M.state.grep_regex_fallback_error = nil
     if M.state.query == '' then
       -- Empty query: show empty state (no search needed)

--- a/plugin/fff.lua
+++ b/plugin/fff.lua
@@ -49,6 +49,10 @@ end, {
   desc = 'Find files with FFF (use directory path or search query)',
 })
 
+vim.api.nvim_create_user_command('FFFOldFiles', function() require('fff').find_oldfiles() end, {
+  desc = 'Find recently opened files',
+})
+
 vim.api.nvim_create_user_command('FFFScan', function() require('fff').scan_files() end, {
   desc = 'Scan files for FFF',
 })


### PR DESCRIPTION
## Summary

- Adds `find_oldfiles()` API and `:FFFOldFiles` command to browse recently opened files (`vim.v.oldfiles`)
- New `oldfiles` mode in the picker with Lua-side fuzzy filtering
- Reuses existing picker UI, file renderer, preview, and keymaps — zero Rust changes

## Motivation

Users coming from Telescope expect an oldfiles/recent files picker that works across projects. FFF's frecency system only tracks files within the current indexed directory, so files opened in other projects don't appear. This fills that gap.

## Implementation

- `lua/fff/oldfiles.lua` — reads `vim.v.oldfiles`, filters readable files, builds `FileItem`-compatible tables, fuzzy matches against query
- `lua/fff/main.lua` — new `M.find_oldfiles(opts)` entry point
- `lua/fff/picker_ui.lua` — new `'oldfiles'` branch in `update_results_sync()` (5 lines)
- `plugin/fff.lua` — `:FFFOldFiles` user command

## Usage

```lua
-- As keybinding
{ "fo", function() require("fff").find_oldfiles() end, desc = "Recent files" }

-- As command
:FFFOldFiles
```

## Test plan

- [x] Open files in different projects, verify they appear in oldfiles picker
- [x] Fuzzy search filters results correctly
- [x] File selection opens the correct file
- [x] Preview works for oldfiles items
- [x] Works with both `prompt_position = "top"` and `"bottom"`