### PR TITLE
feat/pi events protocol

### DIFF
--- a/packages/fff-node/package.json
+++ b/packages/fff-node/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "test": "node test/e2e.mjs",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -323,9 +323,6 @@ export default function fffExtension(pi: ExtensionAPI) {
   const hasHashlineReadmap = !!(globalThis as any).__piHashlineReadmap;
   if (hasHashlineReadmap) {
     currentMode = "ui-only";
-  } else if (currentMode === "ui-only") {
-    // ui-only mode without pi-hashline-readmap is meaningless — fall back
-    currentMode = "tools-and-ui";
   }
 
   const toolNames = resolveToolNames(currentMode);
@@ -984,11 +981,6 @@ export default function fffExtension(pi: ExtensionAPI) {
       }
 
       const newMode = arg as FffMode;
-
-		if (newMode === "ui-only" && !hasHashlineReadmap) {
-			ctx.ui.notify("ui-only mode requires pi-hashline-readmap", "warning");
-			return;
-		}
       const oldMode = getMode();
       setMode(newMode);
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -32,9 +32,9 @@ const DEFAULT_FIND_LIMIT = 30;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
 
-type FffMode = "tools-and-ui" | "tools-only" | "override";
+type FffMode = "tools-and-ui" | "tools-only" | "override" | "ui-only";
 
-const VALID_MODES: FffMode[] = ["tools-and-ui", "tools-only", "override"];
+const VALID_MODES: FffMode[] = ["tools-and-ui", "tools-only", "override", "ui-only"];
 
 interface ToolNames {
   grep: string;
@@ -54,7 +54,9 @@ const OVERRIDE_TOOL_NAMES: ToolNames = {
 };
 
 function resolveToolNames(mode: FffMode): ToolNames {
-  return mode === "override" ? OVERRIDE_TOOL_NAMES : FFF_TOOL_NAMES;
+  if (mode === "override") return OVERRIDE_TOOL_NAMES;
+  if (mode === "ui-only") return { grep: "", find: "", multiGrep: "" };
+  return FFF_TOOL_NAMES;
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +300,30 @@ export default function fffExtension(pi: ExtensionAPI) {
     (pi.getFlag("fff-mode") as FffMode) ??
     (process.env.PI_FFF_MODE as FffMode) ??
     "tools-and-ui";
+
+  // ── Cross-extension protocol: expose FFF engine to pi-hashline-readmap ──
+  const fffHandle = {
+    getOrCreateFinder: async (cwd: string): Promise<FileFinder> => {
+      return ensureFinder(cwd);
+    },
+    destroyFinder: () => {
+      destroyFinder();
+    },
+  };
+  (globalThis as any).__piFff = fffHandle;
+
+  // Inject FFF engine into pi-hashline-readmap if already loaded
+  const hashlineApi = (globalThis as any).__piHashlineReadmapApi as
+    { setFffEngine?: (engine: typeof fffHandle) => void } | undefined;
+  if (hashlineApi?.setFffEngine) {
+    hashlineApi.setFffEngine(fffHandle);
+  }
+
+  // Detect pi-hashline-readmap presence — auto-enter ui-only mode
+  const hasHashlineReadmap = !!(globalThis as any).__piHashlineReadmap;
+  if (hasHashlineReadmap) {
+    currentMode = "ui-only";
+  }
 
   const toolNames = resolveToolNames(currentMode);
 
@@ -559,6 +585,8 @@ export default function fffExtension(pi: ExtensionAPI) {
     ),
   });
 
+  if (!hasHashlineReadmap) {
+
   pi.registerTool({
     name: toolNames.grep,
     label: toolNames.grep,
@@ -693,6 +721,10 @@ export default function fffExtension(pi: ExtensionAPI) {
     },
   });
 
+  } // end: if (!hasHashlineReadmap)
+
+  if (!hasHashlineReadmap) {
+
   // --- find tool ---
 
   const findSchema = Type.Object({
@@ -823,6 +855,10 @@ export default function fffExtension(pi: ExtensionAPI) {
     },
   });
 
+  } // end: if (!hasHashlineReadmap)
+
+  if (!hasHashlineReadmap) {
+
   // --- multi_grep tool ---
   // My latest tests are showing that the multi grep tool is only harmful, trying to get rid of it
   const enableMultiGrep = process.env.PI_FFF_MULTIGREP === "1";
@@ -920,6 +956,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       },
     });
   } // end if (enableMultiGrep)
+  } // end: if (!hasHashlineReadmap)
 
   // --- commands ---
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -312,19 +312,21 @@ export default function fffExtension(pi: ExtensionAPI) {
   };
   (globalThis as any).__piFff = fffHandle;
 
-  // Inject FFF engine into pi-hashline-readmap if already loaded
-  const hashlineApi = (globalThis as any).__piHashlineReadmapApi as
+  // Primary: pi.events handoff (synchronous, fires during emit())
+  pi.events.on("hashline:ready", () => {
+    pi.events.emit("fff:engine-ready", fffHandle);
+  });
+  pi.events.emit("fff:engine-ready", fffHandle);
+
+  // Fallback: globalThis injection
+  const api = (globalThis as any).__piHashlineReadmapApi as
     { setFffEngine?: (engine: typeof fffHandle) => void } | undefined;
-  if (hashlineApi?.setFffEngine) {
-    hashlineApi.setFffEngine(fffHandle);
+  if (api?.setFffEngine) {
+    api.setFffEngine(fffHandle);
   }
 
-  // Detect pi-hashline-readmap presence — auto-enter ui-only mode
-  const hasHashlineReadmap = !!(globalThis as any).__piHashlineReadmap;
-  if (hasHashlineReadmap) {
-    currentMode = "ui-only";
-  }
-
+  // Tool registration is deferred to queueMicrotask so __piHashlineReadmap
+  // is reliably set (all synchronous factories finish first).
   const toolNames = resolveToolNames(currentMode);
 
   // DB path resolution: flag > env > undefined (use fff-node defaults)
@@ -585,7 +587,7 @@ export default function fffExtension(pi: ExtensionAPI) {
     ),
   });
 
-  if (!hasHashlineReadmap) {
+  queueMicrotask(() => { if (!(globalThis as any).__piHashlineReadmap) {
 
   pi.registerTool({
     name: toolNames.grep,
@@ -721,9 +723,9 @@ export default function fffExtension(pi: ExtensionAPI) {
     },
   });
 
-  } // end: if (!hasHashlineReadmap)
+  } }); // end: microtask
 
-  if (!hasHashlineReadmap) {
+  queueMicrotask(() => { if (!(globalThis as any).__piHashlineReadmap) {
 
   // --- find tool ---
 
@@ -855,9 +857,9 @@ export default function fffExtension(pi: ExtensionAPI) {
     },
   });
 
-  } // end: if (!hasHashlineReadmap)
+  } }); // end: microtask
 
-  if (!hasHashlineReadmap) {
+  queueMicrotask(() => { if (!(globalThis as any).__piHashlineReadmap) {
 
   // --- multi_grep tool ---
   // My latest tests are showing that the multi grep tool is only harmful, trying to get rid of it
@@ -956,7 +958,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       },
     });
   } // end if (enableMultiGrep)
-  } // end: if (!hasHashlineReadmap)
+  } }); // end: microtask
 
   // --- commands ---
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -323,6 +323,9 @@ export default function fffExtension(pi: ExtensionAPI) {
   const hasHashlineReadmap = !!(globalThis as any).__piHashlineReadmap;
   if (hasHashlineReadmap) {
     currentMode = "ui-only";
+  } else if (currentMode === "ui-only") {
+    // ui-only mode without pi-hashline-readmap is meaningless — fall back
+    currentMode = "tools-and-ui";
   }
 
   const toolNames = resolveToolNames(currentMode);
@@ -981,6 +984,11 @@ export default function fffExtension(pi: ExtensionAPI) {
       }
 
       const newMode = arg as FffMode;
+
+		if (newMode === "ui-only" && !hasHashlineReadmap) {
+			ctx.ui.notify("ui-only mode requires pi-hashline-readmap", "warning");
+			return;
+		}
       const oldMode = getMode();
       setMode(newMode);
 


### PR DESCRIPTION
- **feat: expose FFF engine via globalThis, add ui-only mode when pi-hashline-readmap detected**
- **fix: guard against empty tool name registration, block /fff-mode ui-only without hashline**
- **Revert "fix: guard against empty tool name registration, block /fff-mode ui-only without hashline"**
- **fix: add prepare script so dist/ builds after npm install**
- **feat: pi.events protocol + queueMicrotask deferred registration**
