### PR TITLE
fix: strip NUL bytes from grep line_content (#524)

### DIFF
--- a/lua/fff/grep/grep_renderer.lua
+++ b/lua/fff/grep/grep_renderer.lua
@@ -47,6 +47,10 @@ local function render_match_line(item, ctx)
   -- vim.json.decode may return Blobs for strings with NUL bytes; coerce to string.
   local raw_content = item.line_content
   if type(raw_content) ~= 'string' then raw_content = raw_content and tostring(raw_content) or '' end
+  -- Lua strings with embedded NUL get marshalled to Vim Blobs by vim.fn.*, causing
+  -- E976 in strdisplaywidth. Replace NULs so binary-leaning files (e.g. .hdr textures)
+  -- that slip past binary detection don't crash live grep rendering.
+  if raw_content:find('%z') then raw_content = (raw_content:gsub('%z', ' ')) end
   local content = raw_content
 
   -- Indent + location + separator + content


### PR DESCRIPTION
Closes #524

## Root cause
`line_content` returned by Rust grep can contain NUL bytes for files that pass binary detection (only first 512 bytes are scanned in `crates/fff-core/src/file_picker.rs:2035`). Radiance `.hdr` textures have an ASCII header followed by binary payload, so NULs survive into the matched line via `String::from_utf8_lossy` in `crates/fff-core/src/grep.rs:750`. When that string reaches `vim.fn.strdisplaywidth` at `lua/fff/grep/grep_renderer.lua:56`, Neovim's vim.fn marshaller converts a Lua string with embedded NULs into a Vim Blob, raising `E976: Using a Blob as a String`.

## Fix
Replace NUL bytes with spaces in `render_match_line` before any `vim.fn.*` call. Pure Lua, no allocator hit when no NUL is present (cheap `find('%z')` guard). Note: pattern uses `%z` because LuaJIT's literal `\0` in a non-pattern function does not match NUL bytes via `gsub` reliably; the `%z` class does.

## Steps to reproduce
On pre-fix `main`:
```sh
mkdir /tmp/fff-524 && cd /tmp/fff-524
printf '#?RADIANCE\nFORMAT=32-bit_rle_rgbe\nbinary\x00\x00\x00data here\nmore radiance text\n' > tex.hdr
nvim -c 'lua require("fff").setup{}' -c 'lua require("fff").live_grep()'
# in picker: type "radiance"
```
Expected: matches displayed for the ASCII lines of `tex.hdr`.
Actual: `vim.schedule callback: Vim:E976: Using a Blob as a String` with stack trace into `grep_renderer.lua:56` (`strdisplaywidth`).

## How verified
Standalone Lua test (stubbing file_renderer / treesitter_hl) exercising `grep_renderer.render_line` with `line_content` containing embedded NUL bytes, both mid-line and at the start:
```
$ nvim -l /tmp/test_524.lua
OK
OK2
```
Pre-fix the same harness errors with `Vim:E976: Using a Blob as a String`.

Automated triage via Gustav. Honk-Honk 🪿