### PR TITLE
fix: Improve binary detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fff-c"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "fff-query-parser",
  "fff-search",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bstr",
  "memchr",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "fff-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap",
  "fff-query-parser",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "fff-nvim"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "fff-query-parser"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "criterion",
  "zlob",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "fff-search"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/crates/fff-core/src/bigram_filter.rs
+++ b/crates/fff-core/src/bigram_filter.rs
@@ -5,6 +5,8 @@ use std::cell::UnsafeCell;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
 
+use crate::FileItem;
+
 /// Maximum number of distinct bigrams tracked in the inverted index.
 /// 95 printable ASCII chars (32..=126) after lowercasing → ~70 distinct → 4900 possible.
 /// We cap at 5000 to cover all printable bigrams with margin.
@@ -107,14 +109,8 @@ impl BigramIndexBuilder {
         &slab[start..start + self.words]
     }
 
-    // `pub` (via `#[doc(hidden)]`) only so the criterion bench can drive
-    // `add_file_content` directly. External consumers should use
-    // `build_bigram_index` instead.
-    ///
-    /// SAFETY: concurrent callers must partition `file_idx` by
-    /// word-aligned ranges so that `file_idx / 64` never collides across
-    /// threads. The `file_picker::build_bigram_index` driver enforces
-    /// this via `par_chunks` with a word-aligned chunk size.
+    // `pub` (via `#[doc(hidden)]`) only for benchmarking
+    // External consumers should use `build_bigram_index` instead.
     #[doc(hidden)]
     pub fn add_file_content(&self, skip_builder: &Self, file_idx: usize, content: &[u8]) {
         if content.len() < 2 {
@@ -616,7 +612,7 @@ thread_local! {
 /// mmap should only be used by the locked version of grep which absolutely minimizes any riscs
 #[inline]
 fn read_bigram_chunk<'a>(
-    file: &crate::types::FileItem,
+    file: &FileItem,
     base_fd: libc::c_int,
     base_path: &std::path::Path,
     arena: crate::simd_path::ArenaPtr,
@@ -630,10 +626,7 @@ fn read_bigram_chunk<'a>(
     }
 
     let data = &buf[..filled];
-    if crate::file_picker::detect_binary_content(data) {
-        file.set_binary(true);
-        return None;
-    }
+
     Some(data)
 }
 
@@ -681,6 +674,14 @@ pub(crate) fn build_bigram_index(
                             &mut buf[..],
                             &mut path_buf,
                         ) {
+                            // we have to manually ensure that every byte is a valid text byte to
+                            // perform this we have to scan every file, first 512 bytes is not enough
+                            // so basically we rely on the fact that first 2MB will always contain
+                            // an invalid text sequence if this is not a binary file.
+                            //
+                            // Need to find a better way to do this.
+                            file.set_binary(crate::file_picker::detect_binary_content(content));
+
                             builder.add_file_content(&skip_builder, file_idx, content);
                         }
                     });

--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -1987,7 +1987,12 @@ pub fn is_known_binary_extension(path: &Path) -> bool {
         ext,
         // Images
         "png" | "jpg" | "jpeg" | "gif" | "bmp" | "ico" | "webp" | "tiff" | "tif" | "avif" |
-        "heic" | "psd" | "icns" | "cur" | "raw" | "cr2" | "nef" | "dng" | "tga" |
+        "heic" | "heif" | "jxl" | "jp2" | "j2k" | "psd" | "icns" | "cur" | "cr2" |
+        "nef" | "dng" | "tga" |
+        // GPU / VFX texture formats
+        "rgbe" | "hdr" | "exr" | "dds" | "ktx" | "ktx2" | "pvr" | "astc" |
+        // Adobe Illustrator (PDF wrapper) / Apple webarchive / MIME HTML archive
+        "ai" | "webarchive" | "mhtml" |
         // Video/Audio
         "mp4" | "avi" | "mov" | "wmv" | "mkv" | "mp3" | "wav" | "flac" | "ogg" | "m4a" |
         "aac" | "webm" | "flv" | "mpg" | "mpeg" | "wma" | "opus" | "pcm" | "reapeaks" |
@@ -2011,30 +2016,27 @@ pub fn is_known_binary_extension(path: &Path) -> bool {
         // Compiled/Runtime
         "class" | "pyc" | "pyo" | "wasm" | "dex" | "jar" | "war" |
         // OCaml / Swift / Objective-C build artefacts
-        "cmi" | "cmt" | "cmti" | "cmx" | "cof" | "cop" | "nib" |
+        "cmi" | "cmt" | "cmti" | "cmx" | "nib" |
         "swiftdeps" | "swiftdeps~" | "swiftdoc" | "swiftmodule" | "swiftsourceinfo" |
         // ML/Data Science
-        "npy" | "npz" | "pkl" | "pickle" | "h5" | "hdf5" | "pt" | "pth" | "onnx" |
-        "safetensors" | "tfrecord" |
+        "npy" | "npz" | "pkl" | "pickle" | "h5" | "hdf5" | "pt" | "onnx" |
+        "safetensors" | "tfrecord" | "tflite" | "gguf" | "ggml" | "joblib" |
         // 3D/Game assets
-        "glb" | "fbx" | "blend" | "blp" |
-        // Compressed-text formats (gzip/binary on disk)
-        "dia" | "tfx" | "flm" | "bcmap" | "journal" |
+        "glb" | "blend" | "blp" |
+        // Gzipped-XML / binary maps
+        "dia" | "bcmap" |
         // Protobuf wire format
         "pb" |
         // Data/serialized
         "parquet" | "arrow" |
         // IDE/OS metadata
-        "DS_Store" | "suo"
+        "suo"
     )
 }
 
-/// Detect binary content by checking for NUL bytes in the first 512 bytes.
-/// Called lazily when file content is first loaded, not during initial scan.
 #[inline]
 pub(crate) fn detect_binary_content(content: &[u8]) -> bool {
-    let check_len = content.len().min(512);
-    content[..check_len].contains(&0)
+    memchr::memchr(0, content).is_some()
 }
 
 /// Length of the longest shared directory prefix of two relative dir

--- a/crates/fff-core/tests/grep_integration.rs
+++ b/crates/fff-core/tests/grep_integration.rs
@@ -303,6 +303,94 @@ fn plain_text_binary_files_are_skipped() {
 }
 
 #[test]
+fn binary_payload_after_long_ascii_header_is_detected() {
+    // Mimics formats like Radiance .hdr / Apple bplist / Adobe .ai where the
+    // first ~1KB is plain ASCII and the binary payload (NULs) starts later.
+    // The legacy 512-byte sniff missed these; the bigram-build memchr scan
+    // over the whole indexed buffer must catch them.
+    use fff_search::file_picker::FFFMode;
+    use fff_search::{SharedFilePicker, SharedFrecency};
+    use std::time::Duration;
+
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path();
+
+    let mut content = Vec::new();
+    // 1 KiB of plain ASCII header — escapes any small fixed-window NUL sniff.
+    content.extend(std::iter::repeat_n(b'A', 1024));
+    content.extend_from_slice(b"\nmatch this text\n");
+    // Binary payload: NUL bytes that prove the file is not text.
+    content.extend(std::iter::repeat_n(0u8, 256));
+    content.extend_from_slice(b"\nmatch this text\n");
+
+    // Use a *text* extension so the scan-time heuristic does NOT pre-flag it.
+    // Only the bigram-time content scan can mark it binary.
+    fs::write(base.join("header.txt"), &content).unwrap();
+    fs::write(base.join("plain.txt"), b"match this text\n").unwrap();
+
+    let shared_picker = SharedFilePicker::default();
+    let shared_frecency = SharedFrecency::default();
+
+    FilePicker::new_with_shared_state(
+        shared_picker.clone(),
+        shared_frecency.clone(),
+        FilePickerOptions {
+            base_path: base.to_string_lossy().to_string(),
+            enable_mmap_cache: false,
+            enable_content_indexing: true,
+            mode: FFFMode::Neovim,
+            watch: false,
+            ..Default::default()
+        },
+    )
+    .expect("Failed to create FilePicker");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        std::thread::sleep(Duration::from_millis(25));
+        let ready = shared_picker
+            .read()
+            .ok()
+            .and_then(|g| {
+                g.as_ref()
+                    .map(|p| !p.is_scan_active() && p.bigram_index().is_some())
+            })
+            .unwrap_or(false);
+        if ready {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Timed out waiting for bigram build"
+        );
+    }
+
+    let guard = shared_picker.read().unwrap();
+    let picker = guard.as_ref().unwrap();
+
+    let was_flagged = picker
+        .get_files()
+        .iter()
+        .any(|f| f.relative_path(picker).contains("header.txt") && f.is_binary());
+    assert!(
+        was_flagged,
+        "header.txt with NULs past 512 bytes must be flagged binary by the whole-buffer memchr scan"
+    );
+
+    let parsed = parse_grep_query("match this text");
+    let result = picker.grep(&parsed, &plain_opts());
+    assert_eq!(
+        result.files.len(),
+        1,
+        "only plain.txt should be searched; header.txt must be skipped as binary"
+    );
+    assert!(
+        result.files[0].relative_path(picker).contains("plain.txt"),
+        "the only match should come from plain.txt"
+    );
+}
+
+#[test]
 fn plain_text_max_matches_per_file() {
     let tmp = TempDir::new().unwrap();
     let mut content = String::new();


### PR DESCRIPTION
closes https://github.com/dmtrKovalenko/fff/issues/524

Originally we used to scan first 512 bytes which is not enough, here I am adding more files for initial extension triage, making it possible to unmark file as binary and making binary scanning more coherent which should support 99.9999999999% cases not breaking performance really hard