### PR TITLE
chore(deps): update zlob to 1.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "zlob"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3522fa9701b74ec72758aedb96da278f6e0533bc16b6a79090bfb465d4661"
+checksum = "e54a400912c3e0f3520d93968bc9563decf7217e6aeb43141174ab1f53bab744"
 dependencies = [
  "bindgen",
  "bitflags 2.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ heed = "0.22.0"
 ignore = "0.4.22"
 memmap2 = "0.9"
 mimalloc = "0.1.47"
-zlob = "1.3.3"
+zlob = "1.3.4"
 
 mlua = { version = "0.11.1", features = ["module", "luajit"] }
 neo_frizbee = { version = "0.10.2", features = ["match_end_col"] }


### PR DESCRIPTION
Closes #535

## Root cause
zlob pinned to 1.3.3 in Cargo.toml.

## Fix
Bump `zlob = \"1.3.4\"` in Cargo.toml; lockfile updated via `cargo update -p zlob --precise 1.3.4`.

## Steps to reproduce
N/A — dependency bump per maintainer request.

## How verified
- `make build` — release build clean.
- `cargo test` — all tests pass.

Automated triage via Gustav. Honk-Honk 🪿