### PR TITLE
fix: defer file open past picker close to preserve folds (#538)

### DIFF
--- a/lua/fff/picker_ui.lua
+++ b/lua/fff/picker_ui.lua
@@ -2080,39 +2080,40 @@ function M.select(action)
   vim.cmd('stopinsert')
   M.close()
 
-  if action == 'edit' then
-    local current_win = vim.api.nvim_get_current_win()
-    local current_buf = vim.api.nvim_get_current_buf()
-    local current_buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
-    local current_buf_modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
-    local current_winfixbuf = window_has_winfixbuf(current_win)
+  -- Defer file open past picker float teardown. Without this, foldexpr is not
+  -- recomputed on the new window (folds appear missing) on some platforms.
+  vim.schedule(function()
+    if action == 'edit' then
+      local current_win = vim.api.nvim_get_current_win()
+      local current_buf = vim.api.nvim_get_current_buf()
+      local current_buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
+      local current_buf_modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
+      local current_winfixbuf = window_has_winfixbuf(current_win)
 
-    -- If the current window can't host a new buffer (special buftype, non-modifiable,
-    -- or 'winfixbuf' locking it), retarget a suitable window or fall back to a split.
-    -- Without this, :edit raises E1513 ("Cannot switch buffer. 'winfixbuf' is enabled")
-    -- whenever the picker is invoked from a window pinned via :h winfixbuf.
-    local opened_via_split = false
-    if current_buftype ~= '' or not current_buf_modifiable or current_winfixbuf then
-      local suitable_win = find_suitable_window()
-      if suitable_win then
-        vim.api.nvim_set_current_win(suitable_win)
-      elseif current_winfixbuf then
-        vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
-        opened_via_split = true
+      -- If the current window can't host a new buffer (special buftype, non-modifiable,
+      -- or 'winfixbuf' locking it), retarget a suitable window or fall back to a split.
+      -- Without this, :edit raises E1513 ("Cannot switch buffer. 'winfixbuf' is enabled")
+      -- whenever the picker is invoked from a window pinned via :h winfixbuf.
+      local opened_via_split = false
+      if current_buftype ~= '' or not current_buf_modifiable or current_winfixbuf then
+        local suitable_win = find_suitable_window()
+        if suitable_win then
+          vim.api.nvim_set_current_win(suitable_win)
+        elseif current_winfixbuf then
+          vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
+          opened_via_split = true
+        end
       end
+
+      if not opened_via_split then vim.cmd('edit ' .. vim.fn.fnameescape(relative_path)) end
+    elseif action == 'split' then
+      vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
+    elseif action == 'vsplit' then
+      vim.cmd('vsplit ' .. vim.fn.fnameescape(relative_path))
+    elseif action == 'tab' then
+      vim.cmd('tabedit ' .. vim.fn.fnameescape(relative_path))
     end
 
-    if not opened_via_split then vim.cmd('edit ' .. vim.fn.fnameescape(relative_path)) end
-  elseif action == 'split' then
-    vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
-  elseif action == 'vsplit' then
-    vim.cmd('vsplit ' .. vim.fn.fnameescape(relative_path))
-  elseif action == 'tab' then
-    vim.cmd('tabedit ' .. vim.fn.fnameescape(relative_path))
-  end
-
-  -- Derive side effects on vim schedule to ensure they run after the file is opened
-  vim.schedule(function()
     if location then location_utils.jump_to_location(location) end
 
     if query and query ~= '' then

--- a/tests/picker_dir_resolution_spec.lua
+++ b/tests/picker_dir_resolution_spec.lua
@@ -131,6 +131,10 @@ describe('picker find_files_in_dir path resolution (issue #389)', function()
 
     picker_ui.select('edit')
 
+    -- select('edit') defers the actual :edit via vim.schedule (see picker_ui.lua)
+    -- to let picker float teardown finish before opening the file. Flush here.
+    vim.wait(2000, function() return vim.api.nvim_buf_get_name(0) ~= '' end)
+
     local bufname = vim.api.nvim_buf_get_name(0)
     assert.is_true(bufname ~= '', 'expected :edit to open a buffer with a non-empty name')
 


### PR DESCRIPTION
Closes #538

## Root cause

`lua/fff/picker_ui.lua:2105` ran `:edit <file>` synchronously inside the keymap callback while picker float windows were still being torn down by `M.close()` (line 2082). On Windows, `FileType` fired and set `foldmethod=expr` / `foldexpr=v:lua.vim.treesitter.foldexpr()`, but the new window's fold state was not recomputed because `WinEnter`/`BufWinEnter` overlapped with float closure. Result: all options reported correct, yet `foldlevel('.')==0`. Re-applying `:setlocal foldmethod=expr foldexpr=...` invalidated the cache and folds returned.

## Fix

Wrap the `:edit`/`:split`/`:vsplit`/`:tabedit` dispatch in `vim.schedule(...)` so file open runs after picker float teardown completes. The existing post-open side effects (`jump_to_location`, query tracking) already lived in a `vim.schedule` block; merged into the same scheduled callback to preserve ordering.

## Steps to reproduce

`init.lua`:

```lua
vim.opt.fillchars = { foldopen = '󰅀', foldclose = '󰅂', foldsep = ' ', foldinner = ' ' }
vim.opt.foldcolumn = '1'
vim.opt.foldlevel = 99
vim.opt.statuscolumn = '%s%=%l%C'

local group = vim.api.nvim_create_augroup('foo', {})
vim.pack.add({ { src = 'https://github.com/dmtrKovalenko/fff', version = 'v0.8.4' } })

vim.api.nvim_create_autocmd('FileType', {
  group = group,
  pattern = { 'lua' },
  callback = function(args)
    if pcall(vim.treesitter.start, args.buf) then
      vim.opt_local.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
      vim.opt_local.foldmethod = 'expr'
    end
  end,
})
```

On Windows 11, Neovim 0.12.2:

1. `nvim init.lua`
2. `:lua require('fff').find_files()`
3. Select `init.lua`
4. Cursor on a function/block, press `za`

Expected: fold toggles.
Actual (pre-fix): `E490: No fold found`. `:echo foldlevel(line('.'))` returns `0` even though `foldmethod=expr` and `foldexpr` are set correctly.

## How verified

@T1ckbase confirmed in https://github.com/dmtrKovalenko/fff/issues/538#issuecomment that wrapping the edit in `vim.schedule(...)` resolves the issue on Windows 11 / Neovim 0.12.2 / FFF v0.8.4.

Automated triage via Gustav. Honk-Honk 🪿