### PR TITLE
fix(grep): classify oversized files as binary, render NUL placeholder

### DIFF
--- a/crates/fff-core/src/bigram_filter.rs
+++ b/crates/fff-core/src/bigram_filter.rs
@@ -1,5 +1,5 @@
 use ahash::AHashMap;
-use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rayon::slice::ParallelSlice;
 use std::cell::UnsafeCell;
 use std::sync::OnceLock;
@@ -595,6 +595,11 @@ impl BigramOverlay {
 pub(crate) const MAX_INDEXABLE_FILE_SIZE: usize = 2 * 1024 * 1024;
 const BIGRAM_CHUNK_FILES: usize = 4 * 64;
 
+/// Bytes read from the head of each oversized file to classify binary content.
+/// Files larger than `MAX_INDEXABLE_FILE_SIZE` skip the bigram pass, so the
+/// classifier never sees them; this pass plugs that gap so grep can drop them.
+const BINARY_SCAN_HEAD_BYTES: usize = 64 * 1024;
+
 /// Sparse-column cutoff for the skip-1 sub-index. Rare skip columns add
 /// little filtering power but ~25-30% of index memory, so we drop
 /// anything appearing in < 12 % of populated files.
@@ -704,6 +709,60 @@ pub(crate) fn build_bigram_index(
     crate::file_picker::hint_allocator_collect();
 
     index
+}
+
+/// Classify oversized / unindexed files as binary by sniffing the head bytes.
+///
+/// The bigram pass already does this implicitly for indexable files, but
+/// anything above `MAX_INDEXABLE_FILE_SIZE` (or otherwise excluded) never sees
+/// the classifier and reaches grep with `is_binary == false`. Without this
+/// pass embedded NUL bytes leak into the renderer (see issue #546).
+#[tracing::instrument(skip_all, name = "Classify Binary Tail Files", level = tracing::Level::DEBUG)]
+pub(crate) fn classify_binary_tail(
+    files: &[crate::types::FileItem],
+    base_path: &std::path::Path,
+    arena: crate::simd_path::ArenaPtr,
+) {
+    if files.is_empty() {
+        return;
+    }
+
+    #[cfg(unix)]
+    let base_fd: libc::c_int = open_base_dir_fd(base_path);
+    #[cfg(not(unix))]
+    let base_fd: i32 = -1;
+
+    crate::file_picker::BACKGROUND_THREAD_POOL.install(|| {
+        files.par_iter().for_each(|file: &crate::types::FileItem| {
+            if file.is_binary() || file.size == 0 {
+                return;
+            }
+
+            let mut buf = [0u8; BINARY_SCAN_HEAD_BYTES];
+            let mut path_buf = [0u8; crate::simd_path::PATH_BUF_SIZE];
+            let want = (file.size as usize).min(BINARY_SCAN_HEAD_BYTES);
+            let filled = file.read_trimmed_into_buf(
+                base_fd,
+                base_path,
+                arena,
+                &mut path_buf,
+                &mut buf[..want],
+            );
+            if filled == 0 {
+                return;
+            }
+            if crate::file_picker::detect_binary_content(&buf[..filled]) {
+                file.set_binary(true);
+            }
+        });
+    });
+
+    #[cfg(unix)]
+    if base_fd >= 0 {
+        unsafe { libc::close(base_fd) };
+    }
+
+    crate::file_picker::hint_allocator_collect();
 }
 
 /// Open the base directory for the `openat` fast path. Returns `-1` on

--- a/crates/fff-core/src/scan.rs
+++ b/crates/fff-core/src/scan.rs
@@ -7,7 +7,7 @@ use tracing::{error, info};
 
 use crate::FileSync;
 use crate::background_watcher::BackgroundWatcher;
-use crate::bigram_filter::build_bigram_index;
+use crate::bigram_filter::{build_bigram_index, classify_binary_tail};
 use crate::error::Error;
 use crate::file_picker::{BACKGROUND_THREAD_POOL, FFFMode};
 use crate::git::GitStatusCache;
@@ -302,13 +302,20 @@ impl ScanJob {
         }
 
         if config.content_indexing {
-            let indexable_files = &files[..unsafe_snapshot.indexable_count.min(files.len())];
+            let split = unsafe_snapshot.indexable_count.min(files.len());
+            let (indexable_files, tail_files) = files.split_at(split);
             let index = build_bigram_index(indexable_files, &unsafe_snapshot.base_path, arena);
 
             if let Ok(mut guard) = shared_picker.write()
                 && let Some(picker) = guard.as_mut()
             {
                 picker.set_bigram_index(index);
+            }
+
+            // Sniff oversized files the bigram pass skipped so grep can drop
+            // ones with embedded NUL bytes (issue #546).
+            if !signals.cancelled.load(Ordering::Acquire) {
+                classify_binary_tail(tail_files, &unsafe_snapshot.base_path, arena);
             }
         }
 

--- a/lua/fff/grep/grep_renderer.lua
+++ b/lua/fff/grep/grep_renderer.lua
@@ -49,6 +49,14 @@ local function render_match_line(item, ctx)
   if type(raw_content) ~= 'string' then raw_content = raw_content and tostring(raw_content) or '' end
   local content = raw_content
 
+  -- Last-resort guard: if a NUL byte slipped past binary detection, render a
+  -- placeholder instead of the raw bytes. `strdisplaywidth` would otherwise
+  -- raise E976 (Vim treats NUL-bearing strings as Blob). Issue #546.
+  if content:find('\0', 1, true) then
+    content = '<binary content>'
+    item._is_binary_match = true
+  end
+
   -- Indent + location + separator + content
   local indent = ' '
   local prefix_display_w = #indent + #location + #separator


### PR DESCRIPTION
Closes #546

## Root cause

`detect_binary_content` only ran inside the bigram-index pass, and that pass excludes files larger than `MAX_INDEXABLE_FILE_SIZE` (2 MB) — see `crates/fff-core/src/scan.rs:304-306` and `crates/fff-core/src/bigram_filter.rs:683`. Grep's `max_file_size` defaults to 10 MB (`crates/fff-core/src/grep.rs:374`). Any file in (2 MB, 10 MB] without a known-binary extension (e.g. `.codex`, an unsuffixed unix executable) kept `is_binary == false`, entered grep, and embedded NUL bytes reached `vim.fn.strdisplaywidth` at `lua/fff/grep/grep_renderer.lua:56` — Vim treats a Lua string with NULs as a Blob and raises `E976`.

## Fix

1. Rust: new `classify_binary_tail` pass in `crates/fff-core/src/bigram_filter.rs` runs after the bigram build, reads the first 64 KB of every file the bigram pass skipped, and flips `set_binary(true)` when a NUL is found. Wired in `crates/fff-core/src/scan.rs::run_post_scan` over `files[indexable_count..]`.
2. Lua: last-resort guard in `render_match_line` (`lua/fff/grep/grep_renderer.lua`). If `line_content` contains a NUL byte (binary detection failed for any reason), the match is rendered as `<binary content>` instead of the raw bytes. Per maintainer instruction: replace the rendered string, do NOT mutate the underlying value.

## Steps to reproduce

```sh
mkdir /tmp/fff-546 && cd /tmp/fff-546 && git init -q
# 3 MB random payload + ascii tail — > 2 MB indexable cap, < 10 MB grep cap, unknown extension
head -c 3145728 /dev/urandom > big.codex
printf 'CODEX header\nascii line\nmatch_me_token here\n' >> big.codex
nvim -c 'lua require("fff").setup{}' -c 'lua require("fff").live_grep()'
# type: match_me_token
```

Pre-fix on `main`: `vim.schedule callback: Vim:E976: Using a Blob as a String` from `grep_renderer.lua:56`.
Post-fix: file classified as binary by the tail pass and skipped by grep. The Lua guard catches any future regression where a binary file still slips through.

## How verified

- `cargo check` green for `fff-core`.
- Manual repro above: pre-fix triggers `E976`, post-fix the file is dropped from grep results.
- Lua guard confirmed by feeding `\0`-bearing `line_content`: renderer outputs `<binary content>` rather than crashing.

Automated triage via Gustav. Honk-Honk 🪿