### PR TITLE
fix(grep): classify large binaries + lua NUL guard (#546)

### DIFF
--- a/crates/fff-core/src/bigram_filter.rs
+++ b/crates/fff-core/src/bigram_filter.rs
@@ -593,6 +593,14 @@ impl BigramOverlay {
 }
 
 pub(crate) const MAX_INDEXABLE_FILE_SIZE: usize = 2 * 1024 * 1024;
+
+/// Upper bound for the binary-detection prefix read on non-indexable files.
+/// Files larger than `MAX_INDEXABLE_FILE_SIZE` skip the bigram pass, but we
+/// still want them flagged as binary so grep / preview don't ship NUL-bearing
+/// content to the Lua renderer (which raises `E976: Using a Blob as a String`
+/// in `vim.fn.strdisplaywidth`). 2 MB matches the indexable cap and keeps the
+/// added I/O bounded.
+pub(crate) const BINARY_DETECTION_PREFIX: usize = MAX_INDEXABLE_FILE_SIZE;
 const BIGRAM_CHUNK_FILES: usize = 4 * 64;
 
 /// Sparse-column cutoff for the skip-1 sub-index. Rare skip columns add
@@ -704,6 +712,72 @@ pub(crate) fn build_bigram_index(
     crate::file_picker::hint_allocator_collect();
 
     index
+}
+
+/// Read the first `BINARY_DETECTION_PREFIX` bytes of every non-indexable
+/// file and flip `set_binary(true)` when a NUL byte is found. Files larger
+/// than `MAX_INDEXABLE_FILE_SIZE` skip the bigram pass entirely, so without
+/// this step a binary file in the `(2 MB, grep_max_file_size]` window keeps
+/// `is_binary == false` and reaches the grep path. The Lua renderer then
+/// hits `E976: Using a Blob as a String` (issue #546).
+///
+/// Bounded by an explicit `max_file_size` (the active grep cap) so we never
+/// open files we wouldn't grep anyway. Files already flagged binary
+/// (extension match) or with `size <= MAX_INDEXABLE_FILE_SIZE` (covered by
+/// the bigram pass) are skipped.
+#[tracing::instrument(skip_all, name = "Classifying Binary (non-indexable)", level = tracing::Level::DEBUG)]
+pub(crate) fn classify_non_indexable_binary(
+    files: &[crate::types::FileItem],
+    base_path: &std::path::Path,
+    arena: crate::simd_path::ArenaPtr,
+    max_file_size: u64,
+) {
+    if files.is_empty() {
+        return;
+    }
+
+    #[cfg(unix)]
+    let base_fd: libc::c_int = open_base_dir_fd(base_path);
+    #[cfg(not(unix))]
+    let base_fd: i32 = -1;
+
+    crate::file_picker::BACKGROUND_THREAD_POOL.install(|| {
+        files.par_chunks(BIGRAM_CHUNK_FILES).for_each(|chunk| {
+            for file in chunk {
+                if file.is_binary()
+                    || file.size == 0
+                    || file.size <= MAX_INDEXABLE_FILE_SIZE as u64
+                    || file.size > max_file_size
+                {
+                    continue;
+                }
+
+                READ_BUF.with(|read_cell| {
+                    let mut buf = read_cell.borrow_mut();
+                    let mut path_buf = [0u8; crate::simd_path::PATH_BUF_SIZE];
+                    let want = (file.size as usize).min(BINARY_DETECTION_PREFIX);
+                    let filled = file.read_trimmed_into_buf(
+                        base_fd,
+                        base_path,
+                        arena,
+                        &mut path_buf,
+                        &mut buf[..want],
+                    );
+                    if filled == 0 {
+                        return;
+                    }
+                    if crate::file_picker::detect_binary_content(&buf[..filled]) {
+                        file.set_binary(true);
+                    }
+                });
+            }
+        });
+    });
+
+    #[cfg(unix)]
+    if base_fd >= 0 {
+        unsafe { libc::close(base_fd) };
+    }
 }
 
 /// Open the base directory for the `openat` fast path. Returns `-1` on

--- a/crates/fff-core/src/scan.rs
+++ b/crates/fff-core/src/scan.rs
@@ -7,7 +7,7 @@ use tracing::{error, info};
 
 use crate::FileSync;
 use crate::background_watcher::BackgroundWatcher;
-use crate::bigram_filter::build_bigram_index;
+use crate::bigram_filter::{build_bigram_index, classify_non_indexable_binary};
 use crate::error::Error;
 use crate::file_picker::{BACKGROUND_THREAD_POOL, FFFMode};
 use crate::git::GitStatusCache;
@@ -302,13 +302,27 @@ impl ScanJob {
         }
 
         if config.content_indexing {
-            let indexable_files = &files[..unsafe_snapshot.indexable_count.min(files.len())];
+            let indexable_count = unsafe_snapshot.indexable_count.min(files.len());
+            let indexable_files = &files[..indexable_count];
             let index = build_bigram_index(indexable_files, &unsafe_snapshot.base_path, arena);
 
             if let Ok(mut guard) = shared_picker.write()
                 && let Some(picker) = guard.as_mut()
             {
                 picker.set_bigram_index(index);
+            }
+
+            // Bigram pass only flags binary for files <= MAX_INDEXABLE_FILE_SIZE.
+            // Larger files in the (2 MB, grep_max_file_size] window otherwise reach
+            // grep with NUL bytes intact and crash the renderer (#546).
+            if !signals.cancelled.load(Ordering::Acquire) {
+                let non_indexable = &files[indexable_count..];
+                classify_non_indexable_binary(
+                    non_indexable,
+                    &unsafe_snapshot.base_path,
+                    arena,
+                    crate::grep::GrepSearchOptions::default().max_file_size,
+                );
             }
         }
 

--- a/lua/fff/grep/grep_renderer.lua
+++ b/lua/fff/grep/grep_renderer.lua
@@ -49,6 +49,12 @@ local function render_match_line(item, ctx)
   if type(raw_content) ~= 'string' then raw_content = raw_content and tostring(raw_content) or '' end
   local content = raw_content
 
+  -- Last-resort guard for binary content that slipped past Rust-side detection.
+  -- vim.fn.strdisplaywidth crashes with `E976: Using a Blob as a String` on
+  -- strings containing embedded NULs. Show the line as a binary placeholder
+  -- instead of replacing the bytes (#546).
+  if content:find('\0', 1, true) then content = '<binary content>' end
+
   -- Indent + location + separator + content
   local indent = ' '
   local prefix_display_w = #indent + #location + #separator


### PR DESCRIPTION
Closes #546

## Root cause
Bigram pass at `crates/fff-core/src/bigram_filter.rs:683` is the only place that calls `set_binary` based on content. It runs only over `indexable_files` (`size <= MAX_INDEXABLE_FILE_SIZE`, 2 MB). Files in `(2 MB, grep.max_file_size]` (10 MB default) with no binary extension keep `is_binary == false`, enter grep, and ship NUL-bearing `line_content` to the Lua renderer. `vim.fn.strdisplaywidth` at `lua/fff/grep/grep_renderer.lua:56` then raises `E976: Using a Blob as a String`.

## Fix
1. New `classify_non_indexable_binary` post-scan pass (`crates/fff-core/src/bigram_filter.rs`) — reads first 2 MB of every file in `(MAX_INDEXABLE_FILE_SIZE, grep.max_file_size]`, calls `set_binary(true)` on NUL hit. Wired into `ScanJob::run_post_scan` (`crates/fff-core/src/scan.rs`) right after the bigram build, gated on the cancellation flag, off-lock, parallel via `BACKGROUND_THREAD_POOL`. Reuses the existing thread-local `READ_BUF`. Skips files already flagged binary or covered by the bigram pass.
2. Last-resort renderer guard (`lua/fff/grep/grep_renderer.lua:48`) — when `item.line_content` contains `\0`, render the placeholder `<binary content>` instead of feeding the raw bytes to `strdisplaywidth`. Per maintainer instruction: do NOT replace bytes, show placeholder.

`grep.max_file_size` ceiling on the new pass keeps I/O bounded — never opens files we wouldn't grep anyway.

## Steps to reproduce
```sh
mkdir /tmp/fff-546 && cd /tmp/fff-546 && git init -q
head -c 3145728 /dev/urandom > big.codex
printf 'CODEX header\nascii line\nmatch_me_token here\n' >> big.codex
nvim -c 'lua require(\"fff\").setup{}' -c 'lua require(\"fff\").live_grep()'
# type: match_me_token
```
Pre-fix: `E976: Using a Blob as a String` via `lua/fff/grep/grep_renderer.lua:56`.
Post-fix: `big.codex` is classified binary during post-scan and skipped by grep entirely. If a NUL still slips through (e.g. live edits between scans), the renderer prints `<binary content>` for the offending match instead of crashing.

## How verified
- `cargo check -p fff-search` clean.
- `cargo test -p fff-search --lib bigram` 26/26 pass.
- Manual repro with 3 MB random `.codex` file: pre-fix crashes, post-fix renders cleanly.

Note: post-scan classification only runs when `enable_content_indexing` is on (same gate as bigram). The Lua guard covers the case where it's disabled.

Automated triage via Gustav. Honk-Honk 🪿