### PR TITLE
fix: treat .pkl and .pickle as text files

### DIFF
--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -2019,7 +2019,7 @@ pub fn is_known_binary_extension(path: &Path) -> bool {
         "cmi" | "cmt" | "cmti" | "cmx" | "nib" |
         "swiftdeps" | "swiftdeps~" | "swiftdoc" | "swiftmodule" | "swiftsourceinfo" |
         // ML/Data Science
-        "npy" | "npz" | "pkl" | "pickle" | "h5" | "hdf5" | "pt" | "onnx" |
+        "npy" | "npz" | "h5" | "hdf5" | "pt" | "onnx" |
         "safetensors" | "tfrecord" | "tflite" | "gguf" | "ggml" | "joblib" |
         // 3D/Game assets
         "glb" | "blend" | "blp" |


### PR DESCRIPTION
Closes #550

## Root cause
`is_known_binary_extension` in `crates/fff-core/src/file_picker.rs:1981` listed `pkl` and `pickle` under ML/Data Science binaries. `.pkl` is now also the [Pkl configuration language](https://pkl-lang.org/) — plain text. Files were classified binary, so preview rendered as binary.

## Fix
Removed `pkl` and `pickle` from the binary extension match list (file_picker.rs:2022).

## Steps to reproduce
```sh
mkdir /tmp/pkl-repro && cd /tmp/pkl-repro
cat > config.pkl <<'PKL'
name = "example"
port = 8080
PKL
nvim config.pkl
# :FFFFind, select config.pkl — preview shows "binary file" placeholder on pre-fix main.
```

Expected: text preview with syntax. Actual (pre-fix): binary placeholder.

## How verified
`cargo check --workspace` passes. Diff is one line.

Automated triage via Gustav. Honk-Honk 🪿