### PR TITLE
fix: default PathScope inside param block in install-mcp.ps1 (#551)

### DIFF
--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -21,11 +21,8 @@ param(
     [string]$Version = $env:FFF_MCP_VERSION,
     [string]$InstallDir = $env:FFF_MCP_INSTALL_DIR,
     [ValidateSet('User', 'Profile', 'None')]
-    [string]$PathScope
+    [string]$PathScope = $(if ($env:FFF_MCP_PATH_SCOPE) { $env:FFF_MCP_PATH_SCOPE } else { 'User' })
 )
-if (-not $PathScope) {
-    $PathScope = if ($env:FFF_MCP_PATH_SCOPE) { $env:FFF_MCP_PATH_SCOPE } else { 'User' }
-}
 
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
Closes #551

## Root cause
`install-mcp.ps1:23-24` declares `[ValidateSet('User','Profile','None')] [string]$PathScope` with no default, then sets a fallback in the body (lines 26-28). PowerShell runs `ValidateSet` at parameter-bind time, before the body executes, so when the script is invoked via `irm ... | iex` an unbound `$PathScope` is the empty string and fails validation.

## Fix
Move the env-var fallback into the param default expression so the bound value is always one of `User|Profile|None` before `ValidateSet` runs. Drop the now-redundant body assignment.

## Steps to reproduce
On Windows PowerShell 5.1+ or PowerShell 7:

```powershell
irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
```

Expected: installer runs, `$PathScope` defaults to `User`.
Actual:
```
Invoke-Expression: The attribute cannot be added because variable PathScope with value  would no longer be valid.
```

## How verified
Inspection of PowerShell parameter binding semantics: `ValidateSet` attribute runs before the script body, so any default that depends on body code is unreachable. With the default expression inside the `param` block, `$env:FFF_MCP_PATH_SCOPE` is consulted at bind time and falls back to `'User'`, both of which satisfy the set. No PowerShell runtime available in the triage env to execute end-to-end; change is a 1-line param relocation matching the reporter's suggested fix.

Automated triage via Gustav. Honk-Honk 🪿