### PR TITLE
feat: configurable grep location format (#549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ require('fff').setup({
     time_budget_ms = 150,
     modes = { 'plain', 'regex', 'fuzzy' },
     trim_whitespace = false,
+    location_format = ':%d:%d', -- printf format for line:col prefix in grep results, e.g. ':%d' for line-only
   },
   debug = {
     enabled = false, -- show the file info panel next to the preview

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -57,6 +57,7 @@ local M = {}
 --- @field time_budget_ms number
 --- @field modes string[]
 --- @field trim_whitespace boolean
+--- @field location_format string
 
 --- @class FffConfig
 --- @field base_path string
@@ -376,6 +377,10 @@ local function init()
       time_budget_ms = 150, -- Max search time in ms per call (prevents UI freeze, 0 = no limit)
       modes = { 'plain', 'regex', 'fuzzy' }, -- Available grep modes and their cycling order
       trim_whitespace = false, -- Strip leading whitespace from matched lines (useful for cleaner display)
+      -- Format string for the line/column location prefix in grep results.
+      -- Uses vim's printf-style format: %d placeholders for line and column (1-based).
+      -- Default ':%d:%d' renders as ':356:1'. Use ':%d' for line-only ':356'.
+      location_format = ':%d:%d',
     },
   }
 

--- a/lua/fff/grep/grep_renderer.lua
+++ b/lua/fff/grep/grep_renderer.lua
@@ -41,8 +41,15 @@ end
 ---@param item table Grep match item
 ---@param ctx table Render context
 ---@return string The match line string
+local function format_location(item, ctx)
+  local fmt = (ctx.config and ctx.config.grep and ctx.config.grep.location_format) or ':%d:%d'
+  local ok, str = pcall(string.format, fmt, item.line_number or 0, (item.col or 0) + 1)
+  if not ok then str = string.format(':%d:%d', item.line_number or 0, (item.col or 0) + 1) end
+  return str
+end
+
 local function render_match_line(item, ctx)
-  local location = string.format(':%d:%d', item.line_number or 0, (item.col or 0) + 1)
+  local location = format_location(item, ctx)
   local separator = '  '
   -- vim.json.decode may return Blobs for strings with NUL bytes; coerce to string.
   local raw_content = item.line_content
@@ -105,7 +112,7 @@ local function apply_match_highlights(item, ctx, item_idx, buf, ns_id, row, line
   end
 
   -- 2. Location (:line:col) dimmed — use extmark with priority so it layers with cursor
-  local location_str = string.format(':%d:%d', item.line_number or 0, (item.col or 0) + 1)
+  local location_str = format_location(item, ctx)
   local loc_start = indent
   local loc_end = loc_start + #location_str
   if loc_end <= #line_content then


### PR DESCRIPTION
Closes #549

## Root cause
Grep result rows hardcode the location prefix as `:%d:%d` in `lua/fff/grep/grep_renderer.lua:45` and `:108`. No configuration option exposes the format.

## Fix
Add `grep.location_format` config option (vim printf-style format string). Default `:%d:%d` keeps current behavior. Users can set `:%d` for line-only output, or any other `string.format` pattern receiving `(line, col)`.

- `lua/fff/conf.lua` — new field on `FffGrepConfig`, default `:%d:%d`
- `lua/fff/grep/grep_renderer.lua` — `format_location(item, ctx)` helper reads `ctx.config.grep.location_format`, pcalls `string.format` and falls back to default on error
- `README.md` — documents new option

## Steps to reproduce
Pre-fix on `main`:

```lua
require('fff').setup({})
require('fff').live_grep()
```

Type any query — every match line shows `:LINE:COL` (e.g. `:356:1`). No way to shorten via config.

After this PR:

```lua
require('fff').setup({ grep = { location_format = ':%d' } })
require('fff').live_grep()
```

Match lines now show only `:LINE` (e.g. `:356`).

## How verified
- `make lint` (rust unaffected)
- stylua passes
- Default unchanged: existing rendering for `:line:col` and the dedup key in `picker_ui.lua:1888` / multi-select key in `grep_renderer.lua:184` still use raw `(line, col)` so selection identity is preserved.

Automated triage via Gustav. Honk-Honk 🪿