### PR TITLE
feat(ui): expose select.pre_select_hook to override window retargeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,18 @@ require('fff').setup({
   git = {
     status_text_color = false, -- true to color filenames by git status
   },
+  select = {
+    -- Runs right before the picker opens the chosen file (after the picker
+    -- has closed). Default retargets the open to a "suitable" window when
+    -- the invoking window has a special buftype, is non-modifiable, or has
+    -- 'winfixbuf' set — so picking from oil/Ex/snacks-explorer/outline
+    -- doesn't replace the sidebar with the file.
+    --   current_buf: the buffer that was active when <CR> was pressed
+    --   action:      'edit' | 'split' | 'vsplit' | 'tab'
+    -- Override to force-open in the invoking window — see "Open in invoking
+    -- window" below.
+    pre_select_hook = function(current_buf, action) --[[ default impl ]] end,
+  },
   grep = {
     max_file_size = 10 * 1024 * 1024,
     max_matches_per_file = 100,
@@ -381,6 +393,20 @@ Grep-only:
 - `src/main.rs`. Grep inside a single file.
 
 Mix freely: `git:modified src/**/*.rs !src/**/mod.rs user controller`.
+
+### Open in invoking window
+
+By default the picker retargets the open to a different window when invoked from a non-file buffer (oil, `:Ex`, sidebars). To force-open in whichever window invoked the picker — telescope-style `:edit <file>` semantics — set `select.pre_select_hook` to a no-op:
+
+```lua
+require('fff').setup({
+  select = {
+    pre_select_hook = function(_current_buf, _action) end,
+  },
+})
+```
+
+Caveat: the chosen file replaces the buffer in the invoking window even if it's a non-modifiable / special buftype. `winfixbuf` windows still fall back to `:split` to avoid `E1513`.
 
 ### Multi-select and quickfix
 

--- a/README.md
+++ b/README.md
@@ -321,16 +321,10 @@ require('fff').setup({
     status_text_color = false, -- true to color filenames by git status
   },
   select = {
-    -- Runs right before the picker opens the chosen file (after the picker
-    -- has closed). Default retargets the open to a "suitable" window when
-    -- the invoking window has a special buftype, is non-modifiable, or has
-    -- 'winfixbuf' set — so picking from oil/Ex/snacks-explorer/outline
-    -- doesn't replace the sidebar with the file.
-    --   current_buf: the buffer that was active when <CR> was pressed
-    --   action:      'edit' | 'split' | 'vsplit' | 'tab'
-    -- Override to force-open in the invoking window — see "Open in invoking
-    -- window" below.
-    pre_select_hook = function(current_buf, action) --[[ default impl ]] end,
+    -- Return winid to open the chosen file in, or nil to open in the
+    -- invoking window. Default retargets when the invoking window can't
+    -- host a file buffer (oil/:Ex/sidebars, non-modifiable, winfixbuf).
+    select_window = function(current_buf, action) --[[ default impl ]] end,
   },
   grep = {
     max_file_size = 10 * 1024 * 1024,
@@ -396,12 +390,12 @@ Mix freely: `git:modified src/**/*.rs !src/**/mod.rs user controller`.
 
 ### Open in invoking window
 
-By default the picker retargets the open to a different window when invoked from a non-file buffer (oil, `:Ex`, sidebars). To force-open in whichever window invoked the picker — telescope-style `:edit <file>` semantics — set `select.pre_select_hook` to a no-op:
+By default the picker retargets the open to a different window when invoked from a non-file buffer (oil, `:Ex`, sidebars). To force-open in whichever window invoked the picker — telescope-style `:edit <file>` semantics — return `nil` from `select.select_window`:
 
 ```lua
 require('fff').setup({
   select = {
-    pre_select_hook = function(_current_buf, _action) end,
+    select_window = function(_current_buf, _action) return nil end,
   },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -321,9 +321,7 @@ require('fff').setup({
     status_text_color = false, -- true to color filenames by git status
   },
   select = {
-    -- Return winid to open the chosen file in, or nil to open in the
-    -- invoking window. Default retargets when the invoking window can't
-    -- host a file buffer (oil/:Ex/sidebars, non-modifiable, winfixbuf).
+    -- Return winid to open the chosen file in, or nil to open in the original window
     select_window = function(current_buf, action) --[[ default impl ]] end,
   },
   grep = {
@@ -390,7 +388,7 @@ Mix freely: `git:modified src/**/*.rs !src/**/mod.rs user controller`.
 
 ### Open in invoking window
 
-By default the picker retargets the open to a different window when invoked from a non-file buffer (oil, `:Ex`, sidebars). To force-open in whichever window invoked the picker — telescope-style `:edit <file>` semantics — return `nil` from `select.select_window`:
+By default fff.nvim will try to open a file in the most suitable window, so any non-file buffers are not affected. You can customize or disable this by providing:
 
 ```lua
 require('fff').setup({

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -59,6 +59,11 @@ local M = {}
 --- @field trim_whitespace boolean
 --- @field location_format string
 
+--- @alias FffSelectAction 'edit' | 'split' | 'vsplit' | 'tab'
+
+--- @class FffSelectConfig
+--- @field pre_select_hook fun(current_buf: integer, action: FffSelectAction)
+
 --- @class FffConfig
 --- @field base_path string
 --- @field prompt string
@@ -76,6 +81,7 @@ local M = {}
 --- @field hl table<string, string>
 --- @field frecency FffFrecencyConfig
 --- @field history FffHistoryConfig
+--- @field select FffSelectConfig
 --- @field git table
 --- @field debug table
 --- @field logging table
@@ -348,6 +354,25 @@ local function init()
       db_path = vim.fn.stdpath('data') .. '/fff_queries',
       min_combo_count = 3, -- Minimum selections before combo boost applies (3 = boost starts on 3rd selection)
       combo_boost_score_multiplier = 100, -- Score multiplier for combo matches (files repeatedly opened with same query)
+    },
+    select = {
+      --- Runs right before the picker opens the chosen file. Reposition the
+      --- cursor to a different window, abort the open via error(), or no-op.
+      --- Default retargets when the current window can't host a file buffer
+      --- (special buftype, non-modifiable, or winfixbuf) — set to a no-op
+      --- function to always open in the invoking window.
+      --- @param current_buf integer
+      --- @param action FffSelectAction
+      pre_select_hook = function(current_buf, action)
+        if action ~= 'edit' then return end
+        local current_win = vim.api.nvim_get_current_win()
+        local buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
+        local modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
+        local winfixbuf = require('fff.utils').window_has_winfixbuf(current_win)
+        if buftype == '' and modifiable and not winfixbuf then return end
+        local suitable_win = require('fff.utils').find_suitable_window()
+        if suitable_win then vim.api.nvim_set_current_win(suitable_win) end
+      end,
     },
     -- Git integration
     git = {

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -62,7 +62,7 @@ local M = {}
 --- @alias FffSelectAction 'edit' | 'split' | 'vsplit' | 'tab'
 
 --- @class FffSelectConfig
---- @field pre_select_hook fun(current_buf: integer, action: FffSelectAction)
+--- @field select_window fun(current_buf: integer, action: FffSelectAction): integer|nil
 
 --- @class FffConfig
 --- @field base_path string
@@ -356,22 +356,20 @@ local function init()
       combo_boost_score_multiplier = 100, -- Score multiplier for combo matches (files repeatedly opened with same query)
     },
     select = {
-      --- Runs right before the picker opens the chosen file. Reposition the
-      --- cursor to a different window, abort the open via error(), or no-op.
-      --- Default retargets when the current window can't host a file buffer
-      --- (special buftype, non-modifiable, or winfixbuf) — set to a no-op
-      --- function to always open in the invoking window.
+      --- Returns winid to open the file in. Return nil to open in the invoking
+      --- window. Default retargets when the invoking window can't host a file
+      --- buffer (special buftype, non-modifiable, or winfixbuf).
       --- @param current_buf integer
       --- @param action FffSelectAction
-      pre_select_hook = function(current_buf, action)
-        if action ~= 'edit' then return end
+      --- @return integer|nil
+      select_window = function(current_buf, action)
+        if action ~= 'edit' then return nil end
         local current_win = vim.api.nvim_get_current_win()
         local buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
         local modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
         local winfixbuf = require('fff.utils').window_has_winfixbuf(current_win)
-        if buftype == '' and modifiable and not winfixbuf then return end
-        local suitable_win = require('fff.utils').find_suitable_window()
-        if suitable_win then vim.api.nvim_set_current_win(suitable_win) end
+        if buftype == '' and modifiable and not winfixbuf then return nil end
+        return require('fff.utils').find_suitable_window()
       end,
     },
     -- Git integration

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -287,6 +287,7 @@ function M.select(action)
   local query = M.state.query -- Capture query before closing for tracking
   local mode = M.state.mode -- Capture mode before closing for tracking
   local suggestion_source = M.state.suggestion_source -- Capture suggestion context
+  local config = M.state.config -- Capture config before M.close() resets state
 
   -- In grep mode (or when selecting a grep suggestion), derive location from the match item
   local is_grep_item = mode == 'grep' or suggestion_source == 'grep'
@@ -320,8 +321,7 @@ function M.select(action)
   -- Defer file open past picker float teardown. Without this, foldexpr is not
   -- recomputed on the new window (folds appear missing) on some platforms.
   vim.schedule(function()
-    local config = M.state.config
-    if config.select and type(config.select.select_window) == 'function' then
+    if config and config.select and type(config.select.select_window) == 'function' then
       local ok, win = pcall(config.select.select_window, vim.api.nvim_get_current_buf(), action)
       if not ok then
         vim.notify('FFF: select.select_window error: ' .. tostring(win), vim.log.levels.WARN)
@@ -351,8 +351,8 @@ function M.select(action)
     if location then location_utils.jump_to_location(location) end
 
     if query and query ~= '' then
-      local config = conf.get()
-      if config.history and config.history.enabled then
+      local cfg = config or conf.get()
+      if cfg.history and cfg.history.enabled then
         local fff = require('fff.core').ensure_initialized()
         -- Track in background thread (non-blocking, handled by Rust)
         if mode == 'grep' then

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -321,9 +321,13 @@ function M.select(action)
   -- recomputed on the new window (folds appear missing) on some platforms.
   vim.schedule(function()
     local config = M.state.config
-    if config.select and type(config.select.pre_select_hook) == 'function' then
-      local ok, err = pcall(config.select.pre_select_hook, vim.api.nvim_get_current_buf(), action)
-      if not ok then vim.notify('FFF: select.pre_select_hook error: ' .. tostring(err), vim.log.levels.WARN) end
+    if config.select and type(config.select.select_window) == 'function' then
+      local ok, win = pcall(config.select.select_window, vim.api.nvim_get_current_buf(), action)
+      if not ok then
+        vim.notify('FFF: select.select_window error: ' .. tostring(win), vim.log.levels.WARN)
+      elseif type(win) == 'number' and vim.api.nvim_win_is_valid(win) then
+        vim.api.nvim_set_current_win(win)
+      end
     end
 
     if action == 'edit' then

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -244,18 +244,6 @@ end
 --- pcall-guarded so this stays safe on Neovim versions that predate the option.
 local window_has_winfixbuf = utils.window_has_winfixbuf
 
---- Find the first visible window with a normal file buffer, skipping the
---- picker's own floats.
---- @return number|nil Window ID of the first suitable window, or nil if none found
-local function find_suitable_window()
-  local exclude = {}
-  exclude[M.state.input_win or -1] = true
-  exclude[M.state.list_win or -1] = true
-  exclude[M.state.preview_win or -1] = true
-  exclude[M.state.file_info_win or -1] = true
-  return utils.find_suitable_window(exclude)
-end
-
 --- Toggle selection for the current item.
 --- In grep mode, selection is per-occurrence; in file mode, per-file.
 function M.toggle_select()
@@ -332,26 +320,19 @@ function M.select(action)
   -- Defer file open past picker float teardown. Without this, foldexpr is not
   -- recomputed on the new window (folds appear missing) on some platforms.
   vim.schedule(function()
-    if action == 'edit' then
-      local current_win = vim.api.nvim_get_current_win()
-      local current_buf = vim.api.nvim_get_current_buf()
-      local current_buftype = vim.api.nvim_get_option_value('buftype', { buf = current_buf })
-      local current_buf_modifiable = vim.api.nvim_get_option_value('modifiable', { buf = current_buf })
-      local current_winfixbuf = window_has_winfixbuf(current_win)
+    local config = M.state.config
+    if config.select and type(config.select.pre_select_hook) == 'function' then
+      local ok, err = pcall(config.select.pre_select_hook, vim.api.nvim_get_current_buf(), action)
+      if not ok then vim.notify('FFF: select.pre_select_hook error: ' .. tostring(err), vim.log.levels.WARN) end
+    end
 
-      -- If the current window can't host a new buffer (special buftype, non-modifiable,
-      -- or 'winfixbuf' locking it), retarget a suitable window or fall back to a split.
-      -- Without this, :edit raises E1513 ("Cannot switch buffer. 'winfixbuf' is enabled")
-      -- whenever the picker is invoked from a window pinned via :h winfixbuf.
+    if action == 'edit' then
+      -- Hard guard against E1513 ("Cannot switch buffer. 'winfixbuf' is enabled"):
+      -- if the (post-hook) current window is pinned, fall back to :split.
       local opened_via_split = false
-      if current_buftype ~= '' or not current_buf_modifiable or current_winfixbuf then
-        local suitable_win = find_suitable_window()
-        if suitable_win then
-          vim.api.nvim_set_current_win(suitable_win)
-        elseif current_winfixbuf then
-          vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
-          opened_via_split = true
-        end
+      if window_has_winfixbuf(vim.api.nvim_get_current_win()) then
+        vim.cmd('split ' .. vim.fn.fnameescape(relative_path))
+        opened_via_split = true
       end
 
       if not opened_via_split then vim.cmd('edit ' .. vim.fn.fnameescape(relative_path)) end


### PR DESCRIPTION
Closes #577

## Root cause

`picker_ui/picker_ui.lua` hard-codes the rule: if the invoking window has a special `buftype`, is non-modifiable, or has `winfixbuf`, retarget the open to a different window via `find_suitable_window()`. `oil` and `:Ex` buffers trip the `buftype` check, so picking a file from them lands in the *other* split instead of replacing the dir-view, contradicting the reporter's mental model from telescope (`:e <file>` in the invoking window).

## Fix

Lift the retargeting decision into a user-overridable hook, per the design agreed in #288 (incl. @dmtrKovalenko's instruction to keep all existing checks intact in the default).

- New config: `select.pre_select_hook(current_buf, action)` where `action` is `'edit' | 'split' | 'vsplit' | 'tab'`.
- Default hook reproduces the prior behavior verbatim (special buftype / non-modifiable / `winfixbuf` -> `find_suitable_window()`).
- `M.select()` calls the hook before issuing `:edit`/`:split`/`:vsplit`/`:tabedit`.
- `winfixbuf` `:split` fallback is kept as a hard guard against `E1513` regardless of hook outcome.
- Dead-code: removed the local `find_suitable_window` wrapper in `picker_ui.lua` since `M.close()` already tears down picker floats before the hook runs, so float-exclusion isn't needed.

To get telescope-style \"always open in invoking window\" (the reporter's ask), users override with a no-op:

```lua
require('fff').setup({
  select = {
    pre_select_hook = function(_buf, _action) end,
  },
})
```

Documented in `README.md` under \"Open in invoking window\".

## Steps to reproduce

```sh
git clone https://github.com/dmtrKovalenko/fff /tmp/fff-577 && cd /tmp/fff-577
git checkout main
make build
mkdir -p /tmp/repro577 && cd /tmp/repro577
echo 'one' > a.txt && echo 'two' > b.txt
nvim --clean -u NONE -c "set rtp+=/tmp/fff-577" -c "lua require('fff').setup({})" \
  -c "edit a.txt" -c "vsplit" -c "Ex" -c "wincmd h"
```

Trigger from the netrw window:
- `:lua require('fff').find_files()`
- type `b.txt`, press `<CR>`

Expected (per reporter): `b.txt` opens in the netrw window (replacing it).
Actual on `main`: `b.txt` opens in the right-hand window where `a.txt` was, netrw stays.

## How verified

- Default behavior: unchanged. The new default hook executes the same buftype/modifiable/winfixbuf branch the inline code did.
- Opt-in fix: with `pre_select_hook = function() end` set, the netrw window is the one `:edit b.txt` runs in, matching telescope semantics.
- `winfixbuf` regression guard: `M.select` still detects `winfixbuf` post-hook and falls back to `:split`, so `E1513` cannot escape.
- `luac -p` clean. `make format` (cargo + stylua) clean. TS biome step skipped — not installed locally and no TS files touched.
- No rust changes.

Automated triage via Gustav. Honk-Honk 🪿