### PR TITLE
fix(ci): download per-sha nightly binary, keep nightly as rolling alias

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -439,9 +439,11 @@ jobs:
         id: version
         run: lua scripts/determine-version.lua
 
-      # All nightly releases share the same tag and same release in github
+      # Nightlies publish to a permanent per-sha tag (release_tag == version) so
+      # pinned/stale installs always fetch the binary built for their own commit.
+      # The rolling `nightly` tag is also moved to HEAD for "give me latest" tooling.
       - name: Move rolling nightly tag to current commit
-        if: steps.version.outputs.release_tag == 'nightly'
+        if: steps.version.outputs.is_release != 'true'
         run: |
           git tag -f nightly "${{ github.sha }}"
           git push -f origin refs/tags/nightly
@@ -459,6 +461,8 @@ jobs:
           body: |
             ${{ steps.version.outputs.is_release == 'true' && format('Release {0}', steps.version.outputs.version) || format('Nightly release from commit: {0}', github.sha) }}
 
+            npm packages and rust crates are available under this version ${{ steps.version.outputs.version }}
+
             ## Neovim Plugin
             - `{target}.so` / `.dylib` / `.dll` - Lua module for Neovim
 
@@ -468,7 +472,7 @@ jobs:
             ## MCP Server
             - `fff-mcp-{target}` - MCP server binary
 
-            Install with:
+            Update mcp via:
             ```sh
             curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
             ```

--- a/lua/fff/utils/version.lua
+++ b/lua/fff/utils/version.lua
@@ -34,12 +34,18 @@ function M.current_release_tag(repo_root)
   local raw = git(repo_root, 'tag', '--points-at', 'HEAD')
   if not raw then return nil end
 
-  local stable, nightly, dev, other
+  -- A nightly commit carries both the per-sha tag (e.g. 0.9.2-nightly.abc1234,
+  -- which owns a permanent release with that commit's binaries) and the rolling
+  -- `nightly` alias. Prefer the per-sha tag so a pinned install downloads the
+  -- binary built for its own commit, not whatever `nightly` currently points at.
+  local stable, nightly_versioned, nightly_alias, dev, other
   for tag in raw:gmatch('[^\n]+') do
     if tag:match('^v%d') then
       stable = tag
-    elseif tag == 'nightly' or tag:match('%-nightly%.') then
-      nightly = tag
+    elseif tag:match('%-nightly%.') then
+      nightly_versioned = tag
+    elseif tag == 'nightly' then
+      nightly_alias = tag
     elseif tag:match('%-dev%.') then
       dev = tag
     else
@@ -47,7 +53,7 @@ function M.current_release_tag(repo_root)
     end
   end
 
-  return stable or nightly or dev or other
+  return stable or nightly_versioned or dev or other or nightly_alias
 end
 
 function M.read_base_version(repo_root)
@@ -69,7 +75,7 @@ end
 
 ---@class FFFVersionInfo
 ---@field version string semver version (e.g. "0.4.0" or "0.4.1-nightly.abc1234")
----@field release_tag string GitHub release tag for download URLs
+---@field release_tag string permanent GitHub release tag clients download from (per-sha for nightlies)
 ---@field is_release boolean true for tagged stable releases
 ---@field npm_tag string "latest"|"nightly"|"dev"
 
@@ -135,13 +141,13 @@ function M.resolve(repo_root)
   end
 
   local version = string.format('%s-%s.%s', next_version, prerelease_label, short_sha)
-  -- Nightlies publish to a single rolling "nightly" release/tag updated in place,
-  -- so re-publishing never re-notifies watchers. `version` stays unique per-sha
-  -- because crates.io/npm reject duplicate versions.
-  local release_tag = (prerelease_label == 'nightly') and 'nightly' or version
+  -- Each nightly gets its own permanent per-sha release/tag so a pinned or stale
+  -- install always downloads the binary built for its exact commit. CI also moves
+  -- the rolling `nightly` tag to HEAD for "give me latest" tooling, but clients
+  -- never resolve to it when their commit has a per-sha tag.
   return {
     version = version,
-    release_tag = release_tag,
+    release_tag = version,
     is_release = false,
     npm_tag = npm_tag,
   }


### PR DESCRIPTION
## Problem

#580 switched nightly downloads to a single rolling `nightly` release and set `release_tag = 'nightly'`. Any **pinned or stale** install resolves to `nightly` and downloads whatever binary HEAD currently points at — an ABI mismatch against its own bundled Lua/FFI layer. Breaks version resolution for anyone not on bleeding-edge main.
