### PR TITLE
fix(nvim): keep picker movement responsive

### DIFF
--- a/lua/fff/file_picker/preview.lua
+++ b/lua/fff/file_picker/preview.lua
@@ -28,13 +28,15 @@ local function append_buffer_lines(bufnr, lines)
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
 end
 
+local function show_preview_unavailable(bufnr) set_buffer_lines(bufnr, { 'No preview available' }) end
+
 local function set_preview_filetype(bufnr, filetype)
-  -- Preserve user-facing errors from preview-local filetype churn.
+  -- FileType hooks can throw or mutate global v:errmsg during preview setup.
+  -- pcall lets us restore it; callers treat failures as preview-local.
   local errmsg = vim.v.errmsg
-  vim.v.errmsg = ''
   local ok, err = pcall(vim.api.nvim_set_option_value, 'filetype', filetype, { buf = bufnr })
   vim.v.errmsg = errmsg
-  if not ok then error(err) end
+  return ok, err
 end
 
 local function find_existing_buffer(file_path)
@@ -289,7 +291,10 @@ local function link_buffer_content(source_bufnr, target_bufnr)
   set_buffer_lines(target_bufnr, lines)
 
   local source_ft = vim.api.nvim_get_option_value('filetype', { buf = source_bufnr })
-  if source_ft ~= '' then set_preview_filetype(target_bufnr, source_ft) end
+  if source_ft ~= '' then
+    local ok = set_preview_filetype(target_bufnr, source_ft)
+    if not ok then return false end
+  end
 
   M.state.has_more_content = false
   M.state.total_file_lines = #lines
@@ -445,7 +450,11 @@ function M.preview_file(file_path, bufnr)
       set_buffer_lines(bufnr, content)
 
       local file_config = M.get_file_config(file_path)
-      set_preview_filetype(bufnr, info.filetype)
+      local ok = set_preview_filetype(bufnr, info.filetype)
+      if not ok then
+        show_preview_unavailable(bufnr)
+        return
+      end
       vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
       vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
       vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
@@ -564,7 +573,11 @@ function M.preview_binary_file(file_path, bufnr)
   end
 
   set_buffer_lines(bufnr, lines)
-  set_preview_filetype(bufnr, 'text')
+  local ok = set_preview_filetype(bufnr, 'text')
+  if not ok then
+    show_preview_unavailable(bufnr)
+    return false
+  end
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
   vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
 

--- a/lua/fff/file_picker/preview.lua
+++ b/lua/fff/file_picker/preview.lua
@@ -28,6 +28,15 @@ local function append_buffer_lines(bufnr, lines)
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
 end
 
+local function set_preview_filetype(bufnr, filetype)
+  -- Preserve user-facing errors from preview-local filetype churn.
+  local errmsg = vim.v.errmsg
+  vim.v.errmsg = ''
+  local ok, err = pcall(vim.api.nvim_set_option_value, 'filetype', filetype, { buf = bufnr })
+  vim.v.errmsg = errmsg
+  if not ok then error(err) end
+end
+
 local function find_existing_buffer(file_path)
   local abs_path = vim.fn.resolve(vim.fn.fnamemodify(file_path, ':p'))
 
@@ -87,25 +96,27 @@ local function init_dynamic_loading_async(file_path, callback)
   local generation = M.state.preview_generation
 
   vim.uv.fs_open(file_path, 'r', 438, function(err, fd)
-    -- Stale callback: preview moved on to a different file
-    if M.state.preview_generation ~= generation then
-      if fd then pcall(vim.uv.fs_close, fd) end
-      return
-    end
+    vim.schedule(function()
+      -- Stale callback: preview moved on to a different file
+      if M.state.preview_generation ~= generation then
+        if fd then pcall(vim.uv.fs_close, fd) end
+        return
+      end
 
-    if err or not fd then
-      callback(false, 'Failed to open file: ' .. (err or 'unknown error'))
-      return
-    end
+      if err or not fd then
+        callback(false, 'Failed to open file: ' .. (err or 'unknown error'))
+        return
+      end
 
-    M.state.file_operation = {
-      fd = fd,
-      file_path = file_path,
-      position = 0,
-      remainder = '',
-    }
+      M.state.file_operation = {
+        fd = fd,
+        file_path = file_path,
+        position = 0,
+        remainder = '',
+      }
 
-    callback(true)
+      callback(true)
+    end)
   end)
 end
 
@@ -278,7 +289,7 @@ local function link_buffer_content(source_bufnr, target_bufnr)
   set_buffer_lines(target_bufnr, lines)
 
   local source_ft = vim.api.nvim_get_option_value('filetype', { buf = source_bufnr })
-  if source_ft ~= '' then vim.api.nvim_set_option_value('filetype', source_ft, { buf = target_bufnr }) end
+  if source_ft ~= '' then set_preview_filetype(target_bufnr, source_ft) end
 
   M.state.has_more_content = false
   M.state.total_file_lines = #lines
@@ -434,7 +445,7 @@ function M.preview_file(file_path, bufnr)
       set_buffer_lines(bufnr, content)
 
       local file_config = M.get_file_config(file_path)
-      vim.api.nvim_set_option_value('filetype', info.filetype, { buf = bufnr })
+      set_preview_filetype(bufnr, info.filetype)
       vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
       vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
       vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
@@ -553,7 +564,7 @@ function M.preview_binary_file(file_path, bufnr)
   end
 
   set_buffer_lines(bufnr, lines)
-  vim.api.nvim_set_option_value('filetype', 'text', { buf = bufnr })
+  set_preview_filetype(bufnr, 'text')
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
   vim.api.nvim_set_option_value('readonly', true, { buf = bufnr })
 
@@ -839,7 +850,7 @@ function M.clear_buffer(bufnr)
   pcall(vim.treesitter.stop, bufnr)
 
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
-  vim.api.nvim_set_option_value('filetype', '', { buf = bufnr })
+  set_preview_filetype(bufnr, '')
   vim.api.nvim_set_option_value('syntax', '', { buf = bufnr })
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
 

--- a/lua/fff/picker_ui/grep_renderer.lua
+++ b/lua/fff/picker_ui/grep_renderer.lua
@@ -7,6 +7,8 @@ local fuzzy = require('fff.fuzzy')
 local file_renderer = require('fff.picker_ui.file_renderer')
 local tresitter_highlight = require('fff.treesitter_hl')
 
+M.supports_cursor_rerender = true
+
 -- ===== Search Bridge =====
 
 ---@class fff.grep.SearchResult

--- a/lua/fff/picker_ui/grep_renderer.lua
+++ b/lua/fff/picker_ui/grep_renderer.lua
@@ -1,13 +1,13 @@
 --- Grep search bridge and renderer.
 --- Wraps the Rust `live_grep` FFI function with file-based pagination state tracking.
 --- Also provides renderer for live grep results with file grouping.
-local M = {}
+local M = {
+  supports_cursor_rerender = true,
+}
 
 local fuzzy = require('fff.fuzzy')
 local file_renderer = require('fff.picker_ui.file_renderer')
 local tresitter_highlight = require('fff.treesitter_hl')
-
-M.supports_cursor_rerender = true
 
 -- ===== Search Bridge =====
 

--- a/lua/fff/picker_ui/layout_manager.lua
+++ b/lua/fff/picker_ui/layout_manager.lua
@@ -109,11 +109,7 @@ function M.close()
     end
   end
 
-  if S.preview_timer then
-    S.preview_timer:stop()
-    S.preview_timer:close()
-    S.preview_timer = nil
-  end
+  P.close_preview_timer()
 
   S.input_win = nil
   S.list_win = nil
@@ -126,6 +122,9 @@ function M.close()
   S.preview_visible = false
   S.items = {}
   S.filtered_items = {}
+  S.line_to_item = {}
+  S.item_to_lines = {}
+  S.last_render_ctx = nil
   S.cursor = 1
   S.query = ''
   S.ns_id = nil

--- a/lua/fff/picker_ui/navigation.lua
+++ b/lua/fff/picker_ui/navigation.lua
@@ -74,6 +74,7 @@ function M.move_up()
 
   local prompt_position = get_prompt_position()
   local items_count = #S.filtered_items
+  local old_cursor = S.cursor
   local wrap_around = S.config and S.config.wrap_around or false
 
   if prompt_position == 'bottom' then
@@ -114,13 +115,10 @@ function M.move_up()
     end
   end
 
-  P.render_list()
-  if S.mode == 'grep' or S.suggestion_source == 'grep' then
-    P.update_preview_smart()
-  else
-    P.update_preview()
-  end
+  if not P.render_after_cursor_move(old_cursor) then return end
   P.update_status()
+  pcall(vim.cmd, 'redraw')
+  P.update_preview_debounced()
 
   maybe_hide_combo_separator()
 end
@@ -131,6 +129,7 @@ function M.move_down()
 
   local prompt_position = get_prompt_position()
   local items_count = #S.filtered_items
+  local old_cursor = S.cursor
   local wrap_around = S.config and S.config.wrap_around or false
 
   if prompt_position == 'bottom' then
@@ -171,13 +170,10 @@ function M.move_down()
     end
   end
 
-  P.render_list()
-  if S.mode == 'grep' or S.suggestion_source == 'grep' then
-    P.update_preview_smart()
-  else
-    P.update_preview()
-  end
+  if not P.render_after_cursor_move(old_cursor) then return end
   P.update_status()
+  pcall(vim.cmd, 'redraw')
+  P.update_preview_debounced()
 
   maybe_hide_combo_separator()
 end

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -57,9 +57,11 @@ M.get_suggestion_renderer = search_manager.get_suggestion_renderer
 -- Wire renderer module (list rendering, scroll, empty state)
 renderer.init(M)
 M.render_list = renderer.render_list
+M.render_after_cursor_move = renderer.render_after_cursor_move
 
 -- Wire preview_manager module (preview rendering, debounce, clear)
 preview_manager.init(M)
+M.close_preview_timer = preview_manager.close_preview_timer
 M.update_preview_debounced = preview_manager.update_preview_debounced
 M.update_preview_smart = preview_manager.update_preview_smart
 M.update_preview_title = preview_manager.update_preview_title

--- a/lua/fff/picker_ui/picker_ui_state.lua
+++ b/lua/fff/picker_ui/picker_ui_state.lua
@@ -26,6 +26,8 @@ M.state = {
   top = 1,
   query = '',
   line_to_item = {},
+  item_to_lines = {},
+  last_render_ctx = nil,
   location = nil,
 
   -- History cycling state
@@ -69,7 +71,7 @@ M.state = {
   last_preview_file = nil,
   last_preview_location = nil,
   preview_timer = nil,
-  preview_debounce_ms = 100,
+  preview_debounce_ms = 10,
 
   -- Misc
   ns_id = nil,
@@ -112,6 +114,8 @@ function M.reset_state()
   M.state.top = 1
   M.state.query = ''
   M.state.line_to_item = {}
+  M.state.item_to_lines = {}
+  M.state.last_render_ctx = nil
   M.state.location = nil
 
   M.reset_history_state()

--- a/lua/fff/picker_ui/preview_manager.lua
+++ b/lua/fff/picker_ui/preview_manager.lua
@@ -14,22 +14,29 @@ function M.init(parent_module) P = parent_module end
 
 local S = picker_ui_state.state
 
-function M.update_preview_debounced()
-  if S.preview_timer then
-    S.preview_timer:stop()
-    S.preview_timer:close()
-    S.preview_timer = nil
-  end
+function M.close_preview_timer(timer)
+  timer = timer or S.preview_timer
+  if not timer then return end
 
-  S.preview_timer = vim.uv.new_timer()
-  S.preview_timer:start(
+  if S.preview_timer == timer then S.preview_timer = nil end
+  if timer:is_closing() then return end
+
+  timer:stop()
+  timer:close()
+end
+
+function M.update_preview_debounced()
+  M.close_preview_timer()
+
+  local timer = vim.uv.new_timer()
+  S.preview_timer = timer
+  timer:start(
     S.preview_debounce_ms,
     0,
     vim.schedule_wrap(function()
-      if P.state.active then
-        M.update_preview()
-        S.preview_timer = nil
-      end
+      local is_current = S.preview_timer == timer
+      M.close_preview_timer(timer)
+      if is_current and P.state.active then M.update_preview() end
     end)
   )
 end

--- a/lua/fff/picker_ui/renderer.lua
+++ b/lua/fff/picker_ui/renderer.lua
@@ -280,12 +280,9 @@ end
 
 local function rerender_cursor_rows(old_cursor, new_cursor)
   if S.suggestion_source then return false end
-  if not (S.list_buf and vim.api.nvim_buf_is_valid(S.list_buf)) then return false end
-  if not (S.list_win and vim.api.nvim_win_is_valid(S.list_win)) then return false end
-  if not (S.item_to_lines and S.last_render_ctx and S.ns_id) then return false end
 
   local ctx = S.last_render_ctx
-  if ctx.items ~= S.filtered_items then return false end
+  if not ctx or ctx.items ~= S.filtered_items then return false end
   if ctx.renderer and not ctx.renderer.supports_cursor_rerender then return false end
 
   local old_lines = S.item_to_lines[old_cursor]

--- a/lua/fff/picker_ui/renderer.lua
+++ b/lua/fff/picker_ui/renderer.lua
@@ -255,11 +255,15 @@ function M.render_list()
   local ctx = build_render_context()
   if S.mode == 'grep' and #ctx.items == 0 then
     S.line_to_item = {}
+    S.item_to_lines = {}
+    S.last_render_ctx = nil
     render_grep_empty_state(ctx)
     return
   end
 
   local item_to_lines, separator_line = list_renderer.render(ctx, S.list_buf, S.list_win, S.ns_id)
+  S.item_to_lines = item_to_lines
+  S.last_render_ctx = ctx
 
   local line_to_item = {}
   for item_idx, mapping in pairs(item_to_lines) do
@@ -272,6 +276,52 @@ function M.render_list()
   if ctx.prompt_position == 'bottom' then M.scroll_to_bottom() end
 
   finalize_render(separator_line, ctx)
+end
+
+local function rerender_cursor_rows(old_cursor, new_cursor)
+  if S.suggestion_source then return false end
+  if not (S.list_buf and vim.api.nvim_buf_is_valid(S.list_buf)) then return false end
+  if not (S.list_win and vim.api.nvim_win_is_valid(S.list_win)) then return false end
+  if not (S.item_to_lines and S.last_render_ctx and S.ns_id) then return false end
+
+  local ctx = S.last_render_ctx
+  if ctx.items ~= S.filtered_items then return false end
+  if ctx.renderer and not ctx.renderer.supports_cursor_rerender then return false end
+
+  local old_lines = S.item_to_lines[old_cursor]
+  local new_lines = S.item_to_lines[new_cursor]
+  if not old_lines or not new_lines then return false end
+
+  local renderer = ctx.renderer or require('fff.picker_ui.file_renderer')
+  local entries = {
+    { item_idx = old_cursor, lines = old_lines },
+    { item_idx = new_cursor, lines = new_lines },
+  }
+
+  for _, entry in ipairs(entries) do
+    entry.item = ctx.items[entry.item_idx]
+    if not entry.item then return false end
+
+    local line_idx = entry.lines.last
+    entry.line = vim.api.nvim_buf_get_lines(S.list_buf, line_idx - 1, line_idx, false)[1]
+    if not entry.line then return false end
+  end
+
+  ctx.cursor = new_cursor
+  for _, entry in ipairs(entries) do
+    vim.api.nvim_buf_clear_namespace(S.list_buf, S.ns_id, entry.lines.first - 1, entry.lines.last)
+    renderer.apply_highlights(entry.item, ctx, entry.item_idx, S.list_buf, S.ns_id, entry.lines.last, entry.line)
+  end
+
+  vim.api.nvim_win_set_cursor(S.list_win, { new_lines.last, 0 })
+  return true
+end
+
+function M.render_after_cursor_move(old_cursor)
+  if old_cursor == S.cursor then return false end
+  if old_cursor and rerender_cursor_rows(old_cursor, S.cursor) then return true end
+  M.render_list()
+  return true
 end
 
 return M

--- a/tests/picker_ui_snap.lua
+++ b/tests/picker_ui_snap.lua
@@ -41,6 +41,7 @@ local function setup(geometry, opts)
         vim.opt.runtimepath:prepend(plugin)
         package.path = plugin .. '/lua/?.lua;' .. plugin .. '/lua/?/init.lua;' .. package.path
         vim.cmd('cd ' .. vim.fn.fnameescape(%q))
+        vim.cmd('syntax off')
         local winborder = %q
         if winborder ~= '' then vim.o.winborder = winborder end
         vim.g.fff = {


### PR DESCRIPTION
I ran into an issue in Neovim where quickly scrolling through picker results with `<C-n>` / `<C-p>` could make the list freeze until I released the key. In some cases it also produced the error shown below:

<img width="3200" height="2000" alt="screenshot-from-08-06-2026 12-34-58" src="https://github.com/user-attachments/assets/400f81d5-e522-44ce-8a56-7454c845d246" />

This PR improves cursor movement responsiveness by avoiding a full list redraw when moving between results. Instead, for renderers that support it, it only updates the old and new cursor rows.

It also debounces preview updates during navigation so holding movement keys does not immediately trigger preview work for every cursor step. I used `10ms` because it felt responsive in local testing while still reducing repeated preview updates, but I’m happy to adjust that value if there’s a preferred threshold.

Custom renderers fall back to the full render path unless they explicitly opt into the cursor-row optimization, so renderers that change row text based on cursor state keep working correctly.
