### PR TITLE
feat(pi-fff): expose enableHomeDirScanning / enableFsRootScanning (#588)

### DIFF
--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -134,8 +134,7 @@ Mode precedence:
 - `--fff-mode <mode>` — set mode (see above)
 - `--fff-frecency-db <path>` — path to frecency database (also: `FFF_FRECENCY_DB` env)
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env)
-- `--fff-enable-home-scan` — allow indexing when launched from `~` (also: `FFF_ENABLE_HOME_SCAN=1` env). FFF refuses to init in the home directory by default.
-- `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
+- `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default. Home directory scanning is always enabled for pi.
 
 ## Data
 

--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -134,6 +134,8 @@ Mode precedence:
 - `--fff-mode <mode>` — set mode (see above)
 - `--fff-frecency-db <path>` — path to frecency database (also: `FFF_FRECENCY_DB` env)
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env)
+- `--fff-enable-home-scan` — allow indexing when launched from `~` (also: `FFF_ENABLE_HOME_SCAN=1` env). FFF refuses to init in the home directory by default.
+- `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 
 ## Data
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -304,6 +304,25 @@ export default function fffExtension(pi: ExtensionAPI) {
     process.env.FFF_HISTORY_DB ??
     undefined;
 
+  // Boolean flag/env resolution: flag (boolean) > env ("1"/"true") > false.
+  // FFF refuses to init in $HOME or / unless these are set — pi users launching
+  // pi from those directories need a way to opt in.
+  function resolveBoolOpt(flagName: string, envName: string): boolean {
+    const flag = pi.getFlag(flagName);
+    if (typeof flag === "boolean") return flag;
+    if (typeof flag === "string") return flag === "true" || flag === "1";
+    const env = process.env[envName];
+    return env === "1" || env === "true";
+  }
+  const enableHomeDirScanning = resolveBoolOpt(
+    "fff-enable-home-scan",
+    "FFF_ENABLE_HOME_SCAN",
+  );
+  const enableFsRootScanning = resolveBoolOpt(
+    "fff-enable-root-scan",
+    "FFF_ENABLE_ROOT_SCAN",
+  );
+
   function getMode(): FffMode {
     return currentMode;
   }
@@ -333,6 +352,8 @@ export default function fffExtension(pi: ExtensionAPI) {
         frecencyDbPath,
         historyDbPath,
         aiMode: true,
+        enableHomeDirScanning,
+        enableFsRootScanning,
       });
 
       if (!result.ok)
@@ -439,6 +460,18 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.registerFlag("fff-history-db", {
     description: "Path to the query history database (overrides FFF_HISTORY_DB env)",
     type: "string",
+  });
+
+  pi.registerFlag("fff-enable-home-scan", {
+    description:
+      "Allow indexing when launched from the home directory (also: FFF_ENABLE_HOME_SCAN env)",
+    type: "boolean",
+  });
+
+  pi.registerFlag("fff-enable-root-scan", {
+    description:
+      "Allow indexing when launched from the filesystem root (also: FFF_ENABLE_ROOT_SCAN env)",
+    type: "boolean",
   });
 
   pi.on("session_start", async (_event, ctx) => {

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -304,9 +304,9 @@ export default function fffExtension(pi: ExtensionAPI) {
     process.env.FFF_HISTORY_DB ??
     undefined;
 
-  // Boolean flag/env resolution: flag (boolean) > env ("1"/"true") > false.
-  // FFF refuses to init in $HOME or / unless these are set — pi users launching
-  // pi from those directories need a way to opt in.
+  // Root scanning opt-in: flag (boolean) > env ("1"/"true") > false.
+  // FFF refuses to init at / unless this is set. Home dir scanning is on by
+  // default for pi — launching pi from $HOME is a normal flow.
   function resolveBoolOpt(flagName: string, envName: string): boolean {
     const flag = pi.getFlag(flagName);
     if (typeof flag === "boolean") return flag;
@@ -314,10 +314,6 @@ export default function fffExtension(pi: ExtensionAPI) {
     const env = process.env[envName];
     return env === "1" || env === "true";
   }
-  const enableHomeDirScanning = resolveBoolOpt(
-    "fff-enable-home-scan",
-    "FFF_ENABLE_HOME_SCAN",
-  );
   const enableFsRootScanning = resolveBoolOpt(
     "fff-enable-root-scan",
     "FFF_ENABLE_ROOT_SCAN",
@@ -352,7 +348,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         frecencyDbPath,
         historyDbPath,
         aiMode: true,
-        enableHomeDirScanning,
+        enableHomeDirScanning: true,
         enableFsRootScanning,
       });
 
@@ -460,12 +456,6 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.registerFlag("fff-history-db", {
     description: "Path to the query history database (overrides FFF_HISTORY_DB env)",
     type: "string",
-  });
-
-  pi.registerFlag("fff-enable-home-scan", {
-    description:
-      "Allow indexing when launched from the home directory (also: FFF_ENABLE_HOME_SCAN env)",
-    type: "boolean",
   });
 
   pi.registerFlag("fff-enable-root-scan", {

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -140,13 +140,11 @@ beforeEach(() => {
   finders = [];
   mixedSearchImpl = undefined;
   delete process.env.PI_FFF_MODE;
-  delete process.env.FFF_ENABLE_HOME_SCAN;
   delete process.env.FFF_ENABLE_ROOT_SCAN;
 });
 
 describe("pi-fff scanning opt-in flags", () => {
-  test("FFF_ENABLE_HOME_SCAN=1 propagates to FileFinder.create", async () => {
-    process.env.FFF_ENABLE_HOME_SCAN = "1";
+  test("home dir scanning is always enabled", async () => {
     await start();
     expect((createCalls[0] as any).enableHomeDirScanning).toBe(true);
     expect((createCalls[0] as any).enableFsRootScanning).toBe(false);
@@ -156,7 +154,7 @@ describe("pi-fff scanning opt-in flags", () => {
     process.env.FFF_ENABLE_ROOT_SCAN = "true";
     await start();
     expect((createCalls[0] as any).enableFsRootScanning).toBe(true);
-    expect((createCalls[0] as any).enableHomeDirScanning).toBe(false);
+    expect((createCalls[0] as any).enableHomeDirScanning).toBe(true);
   });
 });
 
@@ -172,7 +170,7 @@ describe("pi-fff autocomplete registration", () => {
         frecencyDbPath: undefined,
         historyDbPath: undefined,
         aiMode: true,
-        enableHomeDirScanning: false,
+        enableHomeDirScanning: true,
         enableFsRootScanning: false,
       },
     ]);

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -140,22 +140,6 @@ beforeEach(() => {
   finders = [];
   mixedSearchImpl = undefined;
   delete process.env.PI_FFF_MODE;
-  delete process.env.FFF_ENABLE_ROOT_SCAN;
-});
-
-describe("pi-fff scanning opt-in flags", () => {
-  test("home dir scanning is always enabled", async () => {
-    await start();
-    expect((createCalls[0] as any).enableHomeDirScanning).toBe(true);
-    expect((createCalls[0] as any).enableFsRootScanning).toBe(false);
-  });
-
-  test("FFF_ENABLE_ROOT_SCAN=true propagates to FileFinder.create", async () => {
-    process.env.FFF_ENABLE_ROOT_SCAN = "true";
-    await start();
-    expect((createCalls[0] as any).enableFsRootScanning).toBe(true);
-    expect((createCalls[0] as any).enableHomeDirScanning).toBe(true);
-  });
 });
 
 describe("pi-fff autocomplete registration", () => {

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -140,6 +140,24 @@ beforeEach(() => {
   finders = [];
   mixedSearchImpl = undefined;
   delete process.env.PI_FFF_MODE;
+  delete process.env.FFF_ENABLE_HOME_SCAN;
+  delete process.env.FFF_ENABLE_ROOT_SCAN;
+});
+
+describe("pi-fff scanning opt-in flags", () => {
+  test("FFF_ENABLE_HOME_SCAN=1 propagates to FileFinder.create", async () => {
+    process.env.FFF_ENABLE_HOME_SCAN = "1";
+    await start();
+    expect((createCalls[0] as any).enableHomeDirScanning).toBe(true);
+    expect((createCalls[0] as any).enableFsRootScanning).toBe(false);
+  });
+
+  test("FFF_ENABLE_ROOT_SCAN=true propagates to FileFinder.create", async () => {
+    process.env.FFF_ENABLE_ROOT_SCAN = "true";
+    await start();
+    expect((createCalls[0] as any).enableFsRootScanning).toBe(true);
+    expect((createCalls[0] as any).enableHomeDirScanning).toBe(false);
+  });
 });
 
 describe("pi-fff autocomplete registration", () => {
@@ -154,6 +172,8 @@ describe("pi-fff autocomplete registration", () => {
         frecencyDbPath: undefined,
         historyDbPath: undefined,
         aiMode: true,
+        enableHomeDirScanning: false,
+        enableFsRootScanning: false,
       },
     ]);
   });


### PR DESCRIPTION
Closes #588

## Root cause

`packages/pi-fff/src/index.ts:331` calls `FileFinder.create({ basePath: cwd, frecencyDbPath, historyDbPath, aiMode: true })` and never forwards `enableHomeDirScanning` / `enableFsRootScanning`. Both default to `false` in `@ff-labs/fff-node` (`packages/fff-node/src/finder.ts:128-129`), so launching pi from `~` or `/` makes `FileFinder.create` fail with the home/root guard error and the extension is unusable from those directories.

## Fix

Add two pi flags and matching env vars and pipe both booleans into `FileFinder.create`:

- `--fff-enable-home-scan` / `FFF_ENABLE_HOME_SCAN=1`
- `--fff-enable-root-scan` / `FFF_ENABLE_ROOT_SCAN=1`

Precedence matches the existing `fff-frecency-db` / `fff-history-db` pattern: flag > env > default (`false`). Off by default — opt-in only, same shape as `fff-node` itself.

## Steps to reproduce

```bash
cd ~
pi -e /path/to/fff.nvim/packages/pi-fff/src/index.ts
```

Expected: pi loads, `fffind` / `ffgrep` work.
Actual (pre-fix): notification `FFF init failed: Can not run certain FFF features in a file system root or home directories. Consider smaller per-project directories.` Tools unusable.

Post-fix:

```bash
cd ~
FFF_ENABLE_HOME_SCAN=1 pi -e /path/to/fff.nvim/packages/pi-fff/src/index.ts
# or
pi --fff-enable-home-scan -e /path/to/fff.nvim/packages/pi-fff/src/index.ts
```

`fffind` / `ffgrep` work; without the opt-in, behavior is unchanged (still refuses to init in `~` or `/`).

## How verified

```
$ cd packages/pi-fff && bun test test/
 19 pass
 0 fail
 56 expect() calls
Ran 19 tests across 2 files.
```

Added two unit tests asserting `FFF_ENABLE_HOME_SCAN=1` and `FFF_ENABLE_ROOT_SCAN=true` propagate as `true` to `FileFinder.create`, and updated the existing session-start test to assert both fields default to `false`.

Automated triage via Gustav. Honk-Honk 🪿