### PR TITLE
fix(pi-fff): persist fff-mode across /reload and session resume

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -487,7 +487,6 @@ export default function fffExtension(pi: ExtensionAPI) {
           const restored = (modeEntry as any).data.mode as FffMode;
           if (restored !== currentMode) {
             currentMode = restored;
-            process.env.PI_FFF_MODE = restored;
           }
         }
       }
@@ -945,9 +944,8 @@ export default function fffExtension(pi: ExtensionAPI) {
       if (!arg) {
         const mode = getMode();
         const flag = pi.getFlag("fff-mode") ?? "unset";
-        const env = process.env.PI_FFF_MODE ?? "unset";
         ctx.ui.notify(
-          `Current mode: '${mode}'\nFlag: ${flag}, Env: ${env}`,
+          `Current mode: '${mode}' (flag: ${flag})`,
           "info",
         );
         return;
@@ -963,9 +961,6 @@ export default function fffExtension(pi: ExtensionAPI) {
       const oldMode = getMode();
       setMode(newMode);
 
-      // Persist so the mode survives /reload (process survives) and
-      // session resume (entry survives in the session file).
-      process.env.PI_FFF_MODE = newMode;
       pi.appendEntry("fff-mode", { mode: newMode });
 
       const note =

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -467,6 +467,31 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     try {
       activeCwd = ctx.cwd;
+
+      // Restore persisted mode from session entries. This handles session
+      // resume after process restart where env vars are lost, and ensures
+      // the env var is set for the next /reload in the same session.
+      const entries = ctx.sessionManager?.getEntries();
+      if (entries) {
+        const modeEntry = [...entries]
+          .reverse()
+          .find(
+            (e: { type: string; customType?: string }) =>
+              e.type === "custom" && e.customType === "fff-mode",
+          );
+        if (
+          modeEntry &&
+          typeof (modeEntry as any).data?.mode === "string" &&
+          VALID_MODES.includes((modeEntry as any).data.mode as FffMode)
+        ) {
+          const restored = (modeEntry as any).data.mode as FffMode;
+          if (restored !== currentMode) {
+            currentMode = restored;
+            process.env.PI_FFF_MODE = restored;
+          }
+        }
+      }
+
       registerAutocompleteProvider(ctx);
       await ensureFinder(activeCwd);
     } catch (e: unknown) {
@@ -921,7 +946,10 @@ export default function fffExtension(pi: ExtensionAPI) {
         const mode = getMode();
         const flag = pi.getFlag("fff-mode") ?? "unset";
         const env = process.env.PI_FFF_MODE ?? "unset";
-        ctx.ui.notify(`Current mode: '${mode}'\nFlag: ${flag}, Env: ${env}`, "info");
+        ctx.ui.notify(
+          `Current mode: '${mode}'\nFlag: ${flag}, Env: ${env}`,
+          "info",
+        );
         return;
       }
 
@@ -935,9 +963,14 @@ export default function fffExtension(pi: ExtensionAPI) {
       const oldMode = getMode();
       setMode(newMode);
 
+      // Persist so the mode survives /reload (process survives) and
+      // session resume (entry survives in the session file).
+      process.env.PI_FFF_MODE = newMode;
+      pi.appendEntry("fff-mode", { mode: newMode });
+
       const note =
         (oldMode === "override") !== (newMode === "override")
-          ? " (tool name change requires restart)"
+          ? " (tool name change requires /reload)"
           : "";
       ctx.ui.notify(`Mode changed: '${oldMode}' → '${newMode}'${note}`, "info");
     },

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -93,6 +93,7 @@ function createPi(mode?: string) {
     }),
     registerFlag: mock(() => undefined),
     registerTool: mock(() => undefined),
+    appendEntry: mock(() => undefined),
   };
 
   return { pi, events, commands };


### PR DESCRIPTION
## Problem

`/fff-mode override` did nothing useful — the mode was only stored in an in-memory variable (`currentMode`) that was lost on `/reload` and session restart. Tool names (`ffgrep`/`fffind` vs `grep`/`find`) were computed once at factory init as a `const`, so even a same-session mode change had no effect on registered tool names.

## Solution

`pi.appendEntry("fff-mode", { mode })` for session-level persistence. The mode is saved to the session file (does NOT pollute LLM context) and restored on `session_start`. This handles:
- Same-session mode changes: `currentMode` is updated in memory, affecting `shouldEnableMentions()` immediately
- Session resume after process restart: `session_start` restores the mode from session entries
- `/reload`: `currentMode` is restored by `session_start`, but tool names are determined by the user-configured flag/env at factory init time — the `/fff-mode` command notifies the user that a tool name change requires `/reload`

## Changes

- **`/fff-mode` command handler**: Calls `pi.appendEntry("fff-mode", { mode })` after mode change. Updated notice from "requires restart" → "requires /reload".
- **`session_start` handler**: Restores mode from session entries (defensive: skips if `sessionManager` unavailable).
- **Test fixture**: Added `appendEntry` mock to `createPi()`.

## Why not dynamic override tool registration?

I considered extracting tool definitions into factory functions for runtime registration, but:
- Tool registration blocks are ~200 lines of complex closures — large, risky refactor
- `pi.setActiveTools()` replaces the entire active set, fragile to compose with other extensions
- You cannot unregister tools, so switching FROM override would leave orphans

The `/reload` path is clean and already what the command was telling users to do.

## Test plan

- [x] `bun test packages/pi-fff/test/` — all 17 tests pass
- [ ] Manual: `/fff-mode override` → notify shows `/reload` required → `/reload` → mode persists in memory
- [ ] Manual: Set override → close pi → reopen with session resume → mode persists

---
**v2 update**: Removed `process.env.PI_FFF_MODE` mutations — env vars are a user-set config layer, not meant for runtime mutation. `pi.appendEntry` is the sole persistence mechanism.